### PR TITLE
Add per-incovation panels to results

### DIFF
--- a/src/agentevals/utils/log_enrichment.py
+++ b/src/agentevals/utils/log_enrichment.py
@@ -60,8 +60,16 @@ def enrich_spans_with_logs(
                 seen_user_messages.add(user_content)
 
         elif event_name in ("gen_ai.assistant.message", "gen_ai.choice"):
-            assistant_content = body.get("content") or ""
-            tool_calls = body.get("tool_calls", [])
+            if event_name == "gen_ai.choice":
+                # gen_ai.choice from openai-v2 nests content under body["message"].
+                # Only extract text content here — tool_calls come from gen_ai.assistant.message
+                # events emitted by subsequent LLM calls' input context.
+                nested = body.get("message", {}) if isinstance(body.get("message"), dict) else {}
+                assistant_content = body.get("content") or nested.get("content") or ""
+                tool_calls = []
+            else:
+                assistant_content = body.get("content") or ""
+                tool_calls = body.get("tool_calls", [])
 
             message_key = f"{assistant_content}:{json.dumps(tool_calls) if tool_calls else ''}"
 

--- a/ui/src/components/inspector/ComparisonPanel.tsx
+++ b/ui/src/components/inspector/ComparisonPanel.tsx
@@ -13,6 +13,8 @@ interface ComparisonPanelProps {
   selectedMetrics: string[];
   isEvaluating: boolean;
   performanceMetrics?: PerformanceMetrics;
+  allActualInvocations?: Invocation[];
+  allExpectedInvocations?: Invocation[];
 }
 
 export const ComparisonPanel: React.FC<ComparisonPanelProps> = ({
@@ -23,6 +25,8 @@ export const ComparisonPanel: React.FC<ComparisonPanelProps> = ({
   selectedMetrics,
   isEvaluating,
   performanceMetrics,
+  allActualInvocations,
+  allExpectedInvocations,
 }) => {
   if (!actualInvocation) {
     return (
@@ -67,6 +71,8 @@ export const ComparisonPanel: React.FC<ComparisonPanelProps> = ({
           threshold={threshold}
           selectedMetrics={selectedMetrics}
           isEvaluating={isEvaluating}
+          allActualInvocations={allActualInvocations}
+          allExpectedInvocations={allExpectedInvocations}
         />
       </div>
     </div>

--- a/ui/src/components/inspector/InspectorView.tsx
+++ b/ui/src/components/inspector/InspectorView.tsx
@@ -296,6 +296,8 @@ export const InspectorView: React.FC = () => {
       selectedMetrics={state.selectedMetrics}
       isEvaluating={state.isEvaluating}
       performanceMetrics={traceResult.performanceMetrics}
+      allActualInvocations={invocations}
+      allExpectedInvocations={expectedInvocations}
     />
   );
 

--- a/ui/src/components/inspector/InvocationSummaryPanel.tsx
+++ b/ui/src/components/inspector/InvocationSummaryPanel.tsx
@@ -20,7 +20,7 @@ export const InvocationSummaryPanel: React.FC<InvocationSummaryPanelProps> = ({
   };
 
   // Helper to truncate text
-  const truncateText = (text: string, maxLength: number = 80) => {
+  const truncateText = (text: string, maxLength: number = 200) => {
     if (!text || text.length === 0) return 'No content';
     if (text.length <= maxLength) return text;
     return text.substring(0, maxLength) + '...';

--- a/ui/src/components/inspector/MetricsComparisonSection.tsx
+++ b/ui/src/components/inspector/MetricsComparisonSection.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import { CheckCircle, XCircle, AlertCircle, MinusCircle, Loader2 } from 'lucide-react';
 import type { MetricResult, Invocation } from '../../lib/types';
 import { getStatusColor } from '../../lib/utils';
-import { TrajectoryComparisonDetails } from './TrajectoryComparisonDetails';
 
 interface MetricsComparisonSectionProps {
   metricResults: MetricResult[];
@@ -12,6 +11,8 @@ interface MetricsComparisonSectionProps {
   threshold: number;
   selectedMetrics: string[];
   isEvaluating: boolean;
+  allActualInvocations?: Invocation[];
+  allExpectedInvocations?: Invocation[];
 }
 
 export const MetricsComparisonSection: React.FC<MetricsComparisonSectionProps> = ({
@@ -21,6 +22,8 @@ export const MetricsComparisonSection: React.FC<MetricsComparisonSectionProps> =
   threshold,
   selectedMetrics,
   isEvaluating,
+  allActualInvocations,
+  allExpectedInvocations,
 }) => {
   // Helper to extract text from content parts
   const getTextFromParts = (parts: any[]) => {
@@ -136,6 +139,74 @@ export const MetricsComparisonSection: React.FC<MetricsComparisonSectionProps> =
     };
   };
 
+  const getPerInvocationDetail = (result: MetricResult, idx: number): React.ReactNode => {
+    if (result.metricName === 'tool_trajectory_avg_score' && result.details?.comparisons) {
+      const comp = result.details.comparisons[idx];
+      if (!comp) return null;
+      const diffHint = comp.expected.length > 0 && comp.actual.length > 0
+        ? comp.expected[0].name !== comp.actual[0].name
+          ? 'Tool names differ'
+          : JSON.stringify(comp.expected[0].args) !== JSON.stringify(comp.actual[0].args)
+            ? 'Tool arguments differ'
+            : 'Tool sequences differ'
+        : null;
+      return (
+        <>
+          <div css={miniComparisonGridStyles}>
+            <div>
+              <div css={miniColumnLabelStyles}>Expected</div>
+              {comp.expected.length > 0 ? comp.expected.map((t, i) => (
+                <div key={i} css={miniToolItemStyles}>
+                  <div css={miniToolNameStyles}>{i + 1}. {t.name}</div>
+                  {Object.keys(t.args).length > 0 && (
+                    <pre css={miniArgsStyles}>{JSON.stringify(t.args, null, 2)}</pre>
+                  )}
+                </div>
+              )) : <span css={emptyTextStyles}>(none)</span>}
+            </div>
+            <div>
+              <div css={miniColumnLabelStyles}>Actual</div>
+              {comp.actual.length > 0 ? comp.actual.map((t, i) => (
+                <div key={i} css={miniToolItemStyles}>
+                  <div css={miniToolNameStyles}>{i + 1}. {t.name}</div>
+                  {Object.keys(t.args).length > 0 && (
+                    <pre css={miniArgsStyles}>{JSON.stringify(t.args, null, 2)}</pre>
+                  )}
+                </div>
+              )) : <span css={emptyTextStyles}>(none)</span>}
+            </div>
+          </div>
+          {diffHint && !comp.matched && (
+            <div css={diffHintStyles}>{diffHint}</div>
+          )}
+        </>
+      );
+    }
+    if (
+      (result.metricName === 'response_match_score' || result.metricName === 'final_response_match_v2')
+      && allActualInvocations && allExpectedInvocations
+    ) {
+      const actual = allActualInvocations[idx];
+      const expected = allExpectedInvocations[idx];
+      if (!actual || !expected) return null;
+      const actualText = truncateText(getTextFromParts(actual.finalResponse.parts), 120);
+      const expectedText = truncateText(getTextFromParts(expected.finalResponse.parts), 120);
+      return (
+        <div css={miniComparisonGridStyles}>
+          <div>
+            <div css={miniColumnLabelStyles}>Expected</div>
+            <div css={miniTextStyles}>{expectedText}</div>
+          </div>
+          <div>
+            <div css={miniColumnLabelStyles}>Actual</div>
+            <div css={miniTextStyles}>{actualText}</div>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
+
   const metricResultsMap = new Map(metricResults.map(mr => [mr.metricName, mr]));
   const metricsToShow = selectedMetrics.length > 0 ? selectedMetrics : metricResults.map(mr => mr.metricName);
 
@@ -226,18 +297,27 @@ export const MetricsComparisonSection: React.FC<MetricsComparisonSectionProps> =
                 <div css={perInvocationScoresStyles}>
                   <div css={perInvocationLabelStyles}>Per-invocation scores:</div>
                   <div css={scoresListStyles}>
-                    {result.perInvocationScores.map((score, idx) => (
-                      <span key={idx} css={invocationScoreStyles}>
-                        {score !== null ? score.toFixed(2) : 'N/A'}
-                      </span>
-                    ))}
+                    {result.perInvocationScores.map((score, idx) => {
+                      const failing = score !== null && score < threshold;
+                      const scoreColor = score === null
+                        ? 'var(--text-secondary)'
+                        : failing
+                          ? 'var(--status-failure)'
+                          : 'var(--status-success)';
+                      const detail = getPerInvocationDetail(result, idx);
+                      return (
+                        <div key={idx} css={invocationRowWrapperStyles(failing)}>
+                          <div css={invocationScoreRowStyles}>
+                            <span css={invocationLabelStyles}>Inv #{idx + 1}</span>
+                            <span css={invocationScoreValueStyles(scoreColor)}>
+                              {score !== null ? score.toFixed(2) : 'N/A'}
+                            </span>
+                          </div>
+                          {detail && <div css={invocationDetailStyles}>{detail}</div>}
+                        </div>
+                      );
+                    })}
                   </div>
-                </div>
-              )}
-
-              {result.details?.comparisons && (
-                <div css={detailsContainerStyles}>
-                  <TrajectoryComparisonDetails comparisons={result.details.comparisons} />
                 </div>
               )}
             </div>
@@ -466,22 +546,100 @@ const perInvocationLabelStyles = css`
 
 const scoresListStyles = css`
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 4px;
 `;
 
-const invocationScoreStyles = css`
+const invocationScoreRowStyles = css`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const invocationLabelStyles = css`
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  min-width: 48px;
+`;
+
+const invocationScoreValueStyles = (color: string) => css`
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: ${color};
+`;
+
+const invocationRowWrapperStyles = (failing: boolean) => css`
+  border-left: 3px solid ${failing ? 'var(--status-failure)' : 'var(--border-default)'};
+  padding-left: 8px;
+`;
+
+const invocationDetailStyles = css`
+  margin-top: 6px;
+  padding: 8px;
+  background: var(--bg-primary);
+  border-radius: 4px;
+`;
+
+const miniComparisonGridStyles = css`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+`;
+
+const miniColumnLabelStyles = css`
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+`;
+
+const miniToolItemStyles = css`
   font-family: var(--font-mono);
   font-size: 0.75rem;
   color: var(--text-primary);
-  background: var(--bg-primary);
-  padding: 4px 10px;
-  border-radius: 4px;
-  border: 1px solid var(--border-default);
+  padding: 2px 6px;
+  background: var(--bg-elevated);
+  border-radius: 3px;
+  margin-bottom: 2px;
 `;
 
-const detailsContainerStyles = css`
-  padding: 12px 16px;
-  border-top: 1px solid var(--border-default);
-  background: var(--bg-primary);
+const miniTextStyles = css`
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+`;
+
+const miniToolNameStyles = css`
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-primary);
+`;
+
+const miniArgsStyles = css`
+  font-family: var(--font-mono);
+  font-size: 0.688rem;
+  color: var(--text-secondary);
+  margin: 4px 0 0;
+  padding: 4px 6px;
+  background: var(--bg-elevated);
+  border-radius: 2px;
+  overflow-x: auto;
+  line-height: 1.4;
+`;
+
+const diffHintStyles = css`
+  margin-top: 6px;
+  padding: 4px 8px;
+  background: rgba(255, 87, 87, 0.1);
+  border-radius: 3px;
+  font-size: 0.688rem;
+  color: var(--status-failure);
+  font-style: italic;
 `;

--- a/ui/src/components/upload/UploadView.tsx
+++ b/ui/src/components/upload/UploadView.tsx
@@ -196,10 +196,10 @@ export const UploadView: React.FC = () => {
         <div className="header-nav">
           <button
             className="nav-button"
-            onClick={() => actions.setCurrentView('welcome')}
+            onClick={() => actions.setCurrentView(state.evaluationOrigin === 'streaming' ? 'streaming' : 'welcome')}
           >
             <ArrowLeft size={16} />
-            Back to Welcome
+            {state.evaluationOrigin === 'streaming' ? 'Back to Live View' : 'Back to Welcome'}
           </button>
           <div style={{ display: 'flex', gap: '8px' }}>
             {state.annotationQueues.some(q => q.items.length > 0) && (
@@ -227,114 +227,208 @@ export const UploadView: React.FC = () => {
       </div>
 
       <div className="upload-grid">
-        <div className="section">
-          <div className="section-title">Trace Files</div>
-          <FileDropZone
-            title="Drop trace files here"
-            description="Upload one or more Jaeger JSON trace files"
-            multiple
-            onChange={actions.setTraceFiles}
-          />
-          {state.traceFiles.length > 0 && (
-            <div style={{
-              marginTop: 12,
-              padding: '10px',
-              backgroundColor: 'var(--bg-elevated)',
-              borderRadius: '4px',
-              border: '1px solid var(--border-default)'
-            }}>
+        {state.evaluationOrigin === 'streaming' ? (
+          <>
+            <div className="section">
+              <div className="section-title">Trace Files</div>
               <div style={{
-                color: 'var(--text-primary)',
-                fontSize: '12px',
-                fontWeight: 600,
-                marginBottom: '6px'
+                padding: '10px',
+                backgroundColor: 'var(--bg-elevated)',
+                borderRadius: '4px',
+                border: '1px solid var(--border-default)'
               }}>
-                {state.traceFiles.length} file(s) selected:
+                <div style={{ color: 'var(--text-primary)', fontSize: '12px', fontWeight: 600, marginBottom: '6px' }}>
+                  {state.traceFiles.length} file(s) loaded from live session:
+                </div>
+                {state.traceFiles.map((file, idx) => (
+                  <div
+                    key={idx}
+                    style={{
+                      color: 'var(--text-secondary)',
+                      fontSize: '11px',
+                      padding: '3px 6px',
+                      backgroundColor: 'var(--bg-surface)',
+                      borderRadius: '3px',
+                      marginTop: idx > 0 ? '3px' : '0',
+                      fontFamily: 'monospace'
+                    }}
+                  >
+                    {file.name}
+                  </div>
+                ))}
+                {state.isLoadingMetadata && (
+                  <div style={{
+                    marginTop: '8px',
+                    padding: '6px',
+                    backgroundColor: 'var(--bg-surface)',
+                    borderRadius: '3px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    color: 'var(--accent-cyan)',
+                    fontSize: '11px'
+                  }}>
+                    <div className="spinner" />
+                    Extracting trace metadata...
+                  </div>
+                )}
+                {!state.isLoadingMetadata && state.traceMetadata.size > 0 && (
+                  <div style={{
+                    marginTop: '8px',
+                    padding: '6px',
+                    backgroundColor: 'var(--bg-surface)',
+                    borderRadius: '3px',
+                    color: 'var(--status-success)',
+                    fontSize: '11px'
+                  }}>
+                    ✓ {state.traceMetadata.size} trace(s) ready
+                  </div>
+                )}
               </div>
-              {state.traceFiles.map((file, idx) => (
-                <div
-                  key={idx}
-                  style={{
+            </div>
+
+            <div className="section">
+              <div className="section-title">Eval Set (Optional)</div>
+              {state.evalSetFile ? (
+                <div style={{
+                  padding: '10px',
+                  backgroundColor: 'var(--bg-elevated)',
+                  borderRadius: '4px',
+                  border: '1px solid var(--border-default)'
+                }}>
+                  <div style={{ color: 'var(--text-primary)', fontSize: '12px', fontWeight: 600, marginBottom: '6px' }}>
+                    Eval set file:
+                  </div>
+                  <div style={{
                     color: 'var(--text-secondary)',
                     fontSize: '11px',
                     padding: '3px 6px',
                     backgroundColor: 'var(--bg-surface)',
                     borderRadius: '3px',
-                    marginTop: idx > 0 ? '3px' : '0',
                     fontFamily: 'monospace'
-                  }}
-                >
-                  {file.name}
+                  }}>
+                    {state.evalSetFile.name}
+                  </div>
                 </div>
-              ))}
-              {state.isLoadingMetadata && (
-                <div style={{
-                  marginTop: '8px',
-                  padding: '6px',
-                  backgroundColor: 'var(--bg-surface)',
-                  borderRadius: '3px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '8px',
-                  color: 'var(--accent-cyan)',
-                  fontSize: '11px'
-                }}>
-                  <div className="spinner" />
-                  Extracting trace metadata...
-                </div>
-              )}
-              {!state.isLoadingMetadata && state.traceMetadata.size > 0 && (
-                <div style={{
-                  marginTop: '8px',
-                  padding: '6px',
-                  backgroundColor: 'var(--bg-surface)',
-                  borderRadius: '3px',
-                  color: 'var(--status-success)',
-                  fontSize: '11px'
-                }}>
-                  ✓ {state.traceMetadata.size} trace(s) ready
+              ) : (
+                <div style={{ color: 'var(--text-secondary)', fontSize: '12px', padding: '10px 0' }}>
+                  No golden eval set loaded.
                 </div>
               )}
             </div>
-          )}
-        </div>
+          </>
+        ) : (
+          <>
+            <div className="section">
+              <div className="section-title">Trace Files</div>
+              <FileDropZone
+                title="Drop trace files here"
+                description="Upload one or more Jaeger JSON trace files"
+                multiple
+                onChange={actions.setTraceFiles}
+              />
+              {state.traceFiles.length > 0 && (
+                <div style={{
+                  marginTop: 12,
+                  padding: '10px',
+                  backgroundColor: 'var(--bg-elevated)',
+                  borderRadius: '4px',
+                  border: '1px solid var(--border-default)'
+                }}>
+                  <div style={{
+                    color: 'var(--text-primary)',
+                    fontSize: '12px',
+                    fontWeight: 600,
+                    marginBottom: '6px'
+                  }}>
+                    {state.traceFiles.length} file(s) selected:
+                  </div>
+                  {state.traceFiles.map((file, idx) => (
+                    <div
+                      key={idx}
+                      style={{
+                        color: 'var(--text-secondary)',
+                        fontSize: '11px',
+                        padding: '3px 6px',
+                        backgroundColor: 'var(--bg-surface)',
+                        borderRadius: '3px',
+                        marginTop: idx > 0 ? '3px' : '0',
+                        fontFamily: 'monospace'
+                      }}
+                    >
+                      {file.name}
+                    </div>
+                  ))}
+                  {state.isLoadingMetadata && (
+                    <div style={{
+                      marginTop: '8px',
+                      padding: '6px',
+                      backgroundColor: 'var(--bg-surface)',
+                      borderRadius: '3px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                      color: 'var(--accent-cyan)',
+                      fontSize: '11px'
+                    }}>
+                      <div className="spinner" />
+                      Extracting trace metadata...
+                    </div>
+                  )}
+                  {!state.isLoadingMetadata && state.traceMetadata.size > 0 && (
+                    <div style={{
+                      marginTop: '8px',
+                      padding: '6px',
+                      backgroundColor: 'var(--bg-surface)',
+                      borderRadius: '3px',
+                      color: 'var(--status-success)',
+                      fontSize: '11px'
+                    }}>
+                      ✓ {state.traceMetadata.size} trace(s) ready
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
 
-        <div className="section">
-          <div className="section-title">Eval Set (Optional)</div>
-          <FileDropZone
-            title="Drop eval set file here"
-            description="Upload golden eval set JSON for comparison"
-            onChange={(files) => actions.setEvalSet(files[0] || null)}
-          />
-          {state.evalSetFile && (
-            <div style={{
-              marginTop: 12,
-              padding: '10px',
-              backgroundColor: 'var(--bg-elevated)',
-              borderRadius: '4px',
-              border: '1px solid var(--border-default)'
-            }}>
-              <div style={{
-                color: 'var(--text-primary)',
-                fontSize: '12px',
-                fontWeight: 600,
-                marginBottom: '6px'
-              }}>
-                Eval set file:
-              </div>
-              <div style={{
-                color: 'var(--text-secondary)',
-                fontSize: '11px',
-                padding: '3px 6px',
-                backgroundColor: 'var(--bg-surface)',
-                borderRadius: '3px',
-                fontFamily: 'monospace'
-              }}>
-                {state.evalSetFile.name}
-              </div>
+            <div className="section">
+              <div className="section-title">Eval Set (Optional)</div>
+              <FileDropZone
+                title="Drop eval set file here"
+                description="Upload golden eval set JSON for comparison"
+                onChange={(files) => actions.setEvalSet(files[0] || null)}
+              />
+              {state.evalSetFile && (
+                <div style={{
+                  marginTop: 12,
+                  padding: '10px',
+                  backgroundColor: 'var(--bg-elevated)',
+                  borderRadius: '4px',
+                  border: '1px solid var(--border-default)'
+                }}>
+                  <div style={{
+                    color: 'var(--text-primary)',
+                    fontSize: '12px',
+                    fontWeight: 600,
+                    marginBottom: '6px'
+                  }}>
+                    Eval set file:
+                  </div>
+                  <div style={{
+                    color: 'var(--text-secondary)',
+                    fontSize: '11px',
+                    padding: '3px 6px',
+                    backgroundColor: 'var(--bg-surface)',
+                    borderRadius: '3px',
+                    fontFamily: 'monospace'
+                  }}>
+                    {state.evalSetFile.name}
+                  </div>
+                </div>
+              )}
             </div>
-          )}
-        </div>
+          </>
+        )}
 
         <div className="section metrics-section">
           <div className="section-title">Metrics Configuration</div>


### PR DESCRIPTION
This PR 

- adds detailed, per-invocation views to evaluation results, 
- hides upload panels when user is coming from streaming view,
- fixes LangChain-specific parsing bugs that were discovered during (1)