### PR TITLE
Parallelize eval execution

### DIFF
--- a/src/agentevals/api/streaming_routes.py
+++ b/src/agentevals/api/streaming_routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -150,62 +151,58 @@ async def evaluate_sessions(request: EvaluateSessionsRequest):
         json.dump(eval_set_response["eval_set"], eval_set_file)
         eval_set_file.close()
 
-        results = []
+        sessions_to_evaluate = [
+            (session_id, session)
+            for session_id, session in trace_manager.sessions.items()
+            if session.is_complete
+        ]
 
-        logger.info("Evaluating sessions. Total sessions: %d", len(trace_manager.sessions))
+        logger.info("Evaluating %d complete sessions (of %d total)", len(sessions_to_evaluate), len(trace_manager.sessions))
 
-        for session_id, session in trace_manager.sessions.items():
-            logger.info("Checking session %s: is_complete=%s", session_id, session.is_complete)
+        sem = asyncio.Semaphore(5)
 
-            if not session.is_complete:
-                logger.info("Skipping incomplete session: %s", session_id)
-                continue
+        async def eval_one_session(session_id: str, session) -> dict:
+            async with sem:
+                try:
+                    trace_file = await trace_manager._save_spans_to_temp_file(session)
 
-            logger.info("Evaluating session: %s", session_id)
+                    config = EvalRunConfig(
+                        trace_files=[str(trace_file)],
+                        trace_format="otlp-json",
+                        eval_set_file=eval_set_file.name,
+                        metrics=request.metrics,
+                        judge_model=request.judge_model,
+                    )
 
-            try:
-                trace_file = await trace_manager._save_spans_to_temp_file(session)
-                logger.info("Saved trace file for session %s: %s", session_id, trace_file)
+                    eval_result = await run_evaluation(config)
 
-                config = EvalRunConfig(
-                    trace_files=[str(trace_file)],
-                    trace_format="otlp-json",
-                    eval_set_file=eval_set_file.name,
-                    metrics=request.metrics,
-                    judge_model=request.judge_model,
-                )
+                    if eval_result.trace_results:
+                        trace_result = eval_result.trace_results[0]
+                        return {
+                            "sessionId": session_id,
+                            "traceId": trace_result.trace_id,
+                            "numInvocations": trace_result.num_invocations,
+                            "metricResults": [
+                                {
+                                    "metricName": mr.metric_name,
+                                    "score": mr.score,
+                                    "evalStatus": mr.eval_status,
+                                    "error": mr.error,
+                                }
+                                for mr in trace_result.metric_results
+                            ],
+                        }
+                    else:
+                        logger.warning("No trace results for session %s", session_id)
+                        return {"sessionId": session_id, "error": "No trace results"}
 
-                logger.info("Running evaluation for session %s with metrics: %s", session_id, request.metrics)
-                eval_result = await run_evaluation(config)
-                logger.info("Evaluation complete for session %s. Trace results: %d", session_id, len(eval_result.trace_results) if eval_result.trace_results else 0)
+                except Exception as exc:
+                    logger.error(f"Failed to evaluate session {session_id}: {exc}", exc_info=True)
+                    return {"sessionId": session_id, "error": str(exc)}
 
-                if eval_result.trace_results:
-                    trace_result = eval_result.trace_results[0]
-
-                    results.append({
-                        "sessionId": session_id,
-                        "traceId": trace_result.trace_id,
-                        "numInvocations": trace_result.num_invocations,
-                        "metricResults": [
-                            {
-                                "metricName": mr.metric_name,
-                                "score": mr.score,
-                                "evalStatus": mr.eval_status,
-                                "error": mr.error,
-                            }
-                            for mr in trace_result.metric_results
-                        ],
-                    })
-                    logger.info("Added result for session %s", session_id)
-                else:
-                    logger.warning("No trace results for session %s", session_id)
-
-            except Exception as exc:
-                logger.error(f"Failed to evaluate session {session_id}: {exc}", exc_info=True)
-                results.append({
-                    "sessionId": session_id,
-                    "error": str(exc),
-                })
+        results = await asyncio.gather(
+            *[eval_one_session(sid, sess) for sid, sess in sessions_to_evaluate]
+        )
 
         logger.info("Evaluation complete. Total results: %d", len(results))
 

--- a/src/agentevals/config.py
+++ b/src/agentevals/config.py
@@ -39,3 +39,13 @@ class EvalRunConfig(BaseModel):
         default="table",
         description="Output format: 'table', 'json', or 'summary'.",
     )
+
+    max_concurrent_traces: int = Field(
+        default=10,
+        description="Maximum number of traces to evaluate concurrently.",
+    )
+
+    max_concurrent_evals: int = Field(
+        default=5,
+        description="Maximum number of concurrent metric evaluations (LLM API calls).",
+    )

--- a/src/agentevals/runner.py
+++ b/src/agentevals/runner.py
@@ -151,26 +151,44 @@ async def run_evaluation(
     if progress_callback:
         await progress_callback(f"Evaluating {total_traces} trace{'s' if total_traces != 1 else ''}...")
 
-    for idx, conv_result in enumerate(conversion_results):
-        if progress_callback:
-            trace_id_short = conv_result.trace_id[:12] + "..." if len(conv_result.trace_id) > 12 else conv_result.trace_id
-            await progress_callback(f"Trace {idx + 1}/{total_traces}: {trace_id_short}")
+    trace_semaphore = asyncio.Semaphore(config.max_concurrent_traces)
+    eval_semaphore = asyncio.Semaphore(config.max_concurrent_evals)
 
-        trace = trace_map.get(conv_result.trace_id)
+    async def _evaluate_trace_bounded(idx: int, conv_result: ConversionResult) -> TraceResult:
+        async with trace_semaphore:
+            if progress_callback:
+                trace_id_short = conv_result.trace_id[:12] + "..." if len(conv_result.trace_id) > 12 else conv_result.trace_id
+                await progress_callback(f"Trace {idx + 1}/{total_traces}: {trace_id_short}")
 
-        trace_result = await _evaluate_trace(
-            conv_result=conv_result,
-            metrics=config.metrics,
-            eval_set=eval_set,
-            judge_model=config.judge_model,
-            threshold=config.threshold,
-            progress_callback=progress_callback,
-            trace_progress_callback=trace_progress_callback,
-            trace=trace,
-            performance_metrics=perf_metrics_map.get(conv_result.trace_id),
-        )
+            trace = trace_map.get(conv_result.trace_id)
 
-        result.trace_results.append(trace_result)
+            return await _evaluate_trace(
+                conv_result=conv_result,
+                metrics=config.metrics,
+                eval_set=eval_set,
+                judge_model=config.judge_model,
+                threshold=config.threshold,
+                eval_semaphore=eval_semaphore,
+                progress_callback=progress_callback,
+                trace_progress_callback=trace_progress_callback,
+                trace=trace,
+                performance_metrics=perf_metrics_map.get(conv_result.trace_id),
+            )
+
+    trace_results = await asyncio.gather(
+        *[
+            _evaluate_trace_bounded(idx, conv_result)
+            for idx, conv_result in enumerate(conversion_results)
+        ],
+        return_exceptions=True,
+    )
+
+    for tr in trace_results:
+        if isinstance(tr, Exception):
+            logger.error("Unexpected error evaluating trace: %s", tr)
+            result.errors.append(str(tr))
+        else:
+            result.trace_results.append(tr)
 
     if progress_callback:
         await progress_callback("Evaluation complete")
@@ -208,6 +226,7 @@ async def _evaluate_trace(
     eval_set: EvalSet | None,
     judge_model: str | None,
     threshold: float | None,
+    eval_semaphore: asyncio.Semaphore,
     progress_callback: Optional[ProgressCallback] = None,
     trace_progress_callback: Optional[TraceProgressCallback] = None,
     trace = None,
@@ -237,21 +256,25 @@ async def _evaluate_trace(
     if eval_set:
         expected_invocations = _find_expected_invocations(actual_invocations, eval_set)
 
-    for metric_name in metrics:
-        if progress_callback:
-            await progress_callback(f"Running {metric_name}...")
-
-        metric_result = await _evaluate_metric(
-            metric_name=metric_name,
-            actual_invocations=actual_invocations,
-            expected_invocations=expected_invocations,
-            judge_model=judge_model,
-            threshold=threshold,
-        )
-        trace_result.metric_results.append(metric_result)
-
+    async def _eval_metric_with_semaphore(metric_name: str) -> MetricResult:
+        async with eval_semaphore:
+            if progress_callback:
+                await progress_callback(f"Running {metric_name}...")
+            result = await _evaluate_metric(
+                metric_name=metric_name,
+                actual_invocations=actual_invocations,
+                expected_invocations=expected_invocations,
+                judge_model=judge_model,
+                threshold=threshold,
+            )
+        trace_result.metric_results.append(result)
         if trace_progress_callback:
             await trace_progress_callback(trace_result)
+        return result
+
+    await asyncio.gather(
+        *[_eval_metric_with_semaphore(m) for m in metrics]
+    )
 
     return trace_result
 
@@ -317,7 +340,8 @@ async def _evaluate_metric(
                 expected_invocations=expected_invocations,
             )
         else:
-            eval_result: EvaluationResult = evaluator.evaluate_invocations(
+            eval_result: EvaluationResult = await asyncio.to_thread(
+                evaluator.evaluate_invocations,
                 actual_invocations=actual_invocations,
                 expected_invocations=expected_invocations,
             )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -139,6 +139,16 @@ class TestRunner:
         assert len(data["traces"]) == 1
         assert data["traces"][0]["metrics"][0]["score"] == 1.0
 
+    def test_parallel_trace_error_isolation(self):
+        config = EvalRunConfig(
+            trace_files=[HELM_TRACE, "/nonexistent/file.json"],
+            eval_set_file=EVAL_SET,
+            metrics=["tool_trajectory_avg_score"],
+        )
+        result = asyncio.run(run_evaluation(config))
+        assert len(result.trace_results) >= 1
+        assert len(result.errors) >= 1
+
     def test_extract_trace_metadata_adk(self):
         from agentevals.loader.jaeger import JaegerJsonLoader
 


### PR DESCRIPTION
This PR enables the following concurrency

POST /api/evaluate/stream
  - `max_concurrent_traces` (default 10) and `max_concurrent_evals` (default 5) defined in `EvalRunConfig`

POST /api/streaming/evaluate-sessions
  - max 5 concurrent session evals and the same `max_concurrent_evals` (default 5)