### PR TITLE
Add trace/evalset editor

### DIFF
--- a/ui/src/components/upload/EvalSetEditorDrawer.tsx
+++ b/ui/src/components/upload/EvalSetEditorDrawer.tsx
@@ -1,0 +1,308 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { css } from '@emotion/react';
+import { Drawer, Button, Modal, message } from 'antd';
+import { Save } from 'lucide-react';
+import { useTraceContext } from '../../context/TraceContext';
+import { MetadataEditor } from '../builder/MetadataEditor';
+import { EvalCasesList } from '../builder/EvalCasesList';
+import { JsonPreview } from '../builder/JsonPreview';
+import { readFileAsText, convertSnakeToCamel, convertCamelToSnake } from '../../lib/utils';
+import type { EvalSet, EvalSetMetadata, EvalCase, Invocation } from '../../lib/types';
+
+function parseEvalSetFromJson(raw: any): EvalSet {
+  return {
+    eval_set_id: raw.eval_set_id || '',
+    name: raw.name || '',
+    description: raw.description || '',
+    eval_cases: (raw.eval_cases || []).map((ec: any) => ({
+      eval_id: ec.eval_id || '',
+      conversation: (ec.conversation || []).map((inv: any) => convertSnakeToCamel(inv) as Invocation),
+    })),
+  };
+}
+
+function serializeEvalSet(evalSet: EvalSet): string {
+  const raw = {
+    eval_set_id: evalSet.eval_set_id,
+    name: evalSet.name,
+    description: evalSet.description,
+    eval_cases: evalSet.eval_cases.map(ec => ({
+      eval_id: ec.eval_id,
+      conversation: ec.conversation.map(inv => convertCamelToSnake(inv)),
+    })),
+  };
+  return JSON.stringify(raw, null, 2);
+}
+
+interface EvalSetEditorDrawerProps {
+  file: File;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const EvalSetEditorDrawer: React.FC<EvalSetEditorDrawerProps> = ({ file, open, onClose }) => {
+  const { actions } = useTraceContext();
+  const [evalSet, setEvalSet] = useState<EvalSet | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [dirty, setDirty] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setLoading(true);
+    setError(null);
+    setDirty(false);
+
+    readFileAsText(file)
+      .then((content) => {
+        const parsed = JSON.parse(content);
+        setEvalSet(parseEvalSetFromJson(parsed));
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to parse eval set file');
+        setLoading(false);
+      });
+  }, [file, open]);
+
+  const handleClose = useCallback(() => {
+    if (dirty) {
+      Modal.confirm({
+        title: 'Discard changes?',
+        content: 'You have unsaved changes that will be lost.',
+        okText: 'Discard',
+        okType: 'danger',
+        onOk: onClose,
+      });
+    } else {
+      onClose();
+    }
+  }, [dirty, onClose]);
+
+  const handleApply = useCallback(() => {
+    if (!evalSet) return;
+
+    const jsonString = serializeEvalSet(evalSet);
+    const newFile = new File([jsonString], file.name, { type: 'application/json' });
+    actions.setEvalSet(newFile);
+    setDirty(false);
+    message.success('Eval set updated');
+    onClose();
+  }, [evalSet, file.name, actions, onClose]);
+
+  const updateMetadata = useCallback((updates: Partial<EvalSetMetadata>) => {
+    setEvalSet(prev => prev ? { ...prev, ...updates } : null);
+    setDirty(true);
+  }, []);
+
+  const updateCase = useCallback((idx: number, ec: EvalCase) => {
+    setEvalSet(prev => {
+      if (!prev) return null;
+      const newCases = [...prev.eval_cases];
+      newCases[idx] = ec;
+      return { ...prev, eval_cases: newCases };
+    });
+    setDirty(true);
+  }, []);
+
+  const removeCase = useCallback((idx: number) => {
+    setEvalSet(prev => {
+      if (!prev) return null;
+      return { ...prev, eval_cases: prev.eval_cases.filter((_, i) => i !== idx) };
+    });
+    setDirty(true);
+  }, []);
+
+  const addCase = useCallback(() => {
+    setEvalSet(prev => {
+      if (!prev) return null;
+      const newCase: EvalCase = {
+        eval_id: `case_${prev.eval_cases.length + 1}`,
+        conversation: [],
+      };
+      return { ...prev, eval_cases: [...prev.eval_cases, newCase] };
+    });
+    setDirty(true);
+  }, []);
+
+  return (
+    <Drawer
+      title={null}
+      placement="right"
+      width="85%"
+      open={open}
+      onClose={handleClose}
+      destroyOnClose
+      closable={false}
+      styles={{
+        header: { display: 'none' },
+        body: { padding: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--bg-primary)' },
+      }}
+    >
+      <div css={headerStyle}>
+        <div css={leftSectionStyle}>
+          <div css={titleStyle}>
+            <h1>Edit Eval Set</h1>
+            <span css={subtitleStyle}>{file.name}</span>
+          </div>
+          {dirty && <span css={unsavedBadgeStyle}>unsaved changes</span>}
+        </div>
+        <div css={rightSectionStyle}>
+          <Button css={cancelButtonStyle} onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button css={applyButtonStyle} type="primary" icon={<Save size={16} />} onClick={handleApply} disabled={!dirty || !evalSet}>
+            Apply Changes
+          </Button>
+        </div>
+      </div>
+
+      {loading && (
+        <div css={centeredMessageStyle}>Loading eval set...</div>
+      )}
+
+      {error && (
+        <div css={css`${centeredMessageStyle}; color: var(--status-failure);`}>{error}</div>
+      )}
+
+      {!loading && !error && evalSet && (
+        <div css={contentStyle}>
+          <div css={editorPanelStyle}>
+            <MetadataEditor
+              metadata={{
+                eval_set_id: evalSet.eval_set_id,
+                name: evalSet.name,
+                description: evalSet.description,
+              }}
+              onChange={updateMetadata}
+            />
+            <EvalCasesList
+              evalCases={evalSet.eval_cases}
+              onUpdateCase={updateCase}
+              onRemoveCase={removeCase}
+              onAddCase={addCase}
+            />
+          </div>
+          <div css={previewPanelStyle}>
+            <JsonPreview evalSet={evalSet} />
+          </div>
+        </div>
+      )}
+    </Drawer>
+  );
+};
+
+const headerStyle = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+`;
+
+const leftSectionStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+const titleStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  h1 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+`;
+
+const subtitleStyle = css`
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-family: monospace;
+`;
+
+const unsavedBadgeStyle = css`
+  font-size: 0.7rem;
+  color: var(--status-warning);
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: rgba(245, 158, 11, 0.1);
+`;
+
+const rightSectionStyle = css`
+  display: flex;
+  gap: 12px;
+`;
+
+const cancelButtonStyle = css`
+  &.ant-btn {
+    background: transparent;
+    border-color: var(--border-default);
+    color: var(--text-secondary);
+
+    &:hover {
+      border-color: var(--text-secondary);
+      color: var(--text-primary);
+      background: rgba(255, 255, 255, 0.04);
+    }
+  }
+`;
+
+const applyButtonStyle = css`
+  &.ant-btn-primary {
+    background-color: var(--accent-primary);
+    border-color: var(--accent-primary);
+
+    &:hover {
+      background-color: var(--accent-primary);
+      border-color: var(--accent-primary);
+      opacity: 0.85;
+    }
+
+    &:disabled {
+      background-color: rgba(168, 85, 247, 0.3);
+      border-color: transparent;
+      color: rgba(255, 255, 255, 0.4);
+    }
+  }
+`;
+
+const contentStyle = css`
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
+`;
+
+const editorPanelStyle = css`
+  width: 50%;
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: 24px;
+`;
+
+const previewPanelStyle = css`
+  width: 50%;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  overflow-y: auto;
+`;
+
+const centeredMessageStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 48px;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+`;

--- a/ui/src/components/upload/RawJsonPreview.tsx
+++ b/ui/src/components/upload/RawJsonPreview.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { Button, message } from 'antd';
+import { Copy } from 'lucide-react';
+import { copyToClipboard } from '../../lib/utils';
+
+interface RawJsonPreviewProps {
+  content: string;
+  title?: string;
+}
+
+export const RawJsonPreview: React.FC<RawJsonPreviewProps> = ({ content, title = 'JSON Preview' }) => {
+  const handleCopy = async () => {
+    const success = await copyToClipboard(content);
+    if (success) {
+      message.success('Copied to clipboard!');
+    } else {
+      message.error('Failed to copy');
+    }
+  };
+
+  return (
+    <div css={containerStyle}>
+      <div css={headerStyle}>
+        <h3>{title}</h3>
+        <Button
+          size="small"
+          icon={<Copy size={14} />}
+          onClick={handleCopy}
+        >
+          Copy
+        </Button>
+      </div>
+
+      <div css={jsonContainerStyle}>
+        <pre>{content}</pre>
+      </div>
+    </div>
+  );
+};
+
+const containerStyle = css`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+const headerStyle = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid var(--border-default);
+
+  h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+  }
+`;
+
+const jsonContainerStyle = css`
+  flex: 1;
+  overflow: auto;
+  padding: 16px;
+
+  pre {
+    margin: 0;
+    font-size: 0.75rem;
+    font-family: monospace;
+    color: var(--text-primary);
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+`;

--- a/ui/src/components/upload/TraceEditorDrawer.tsx
+++ b/ui/src/components/upload/TraceEditorDrawer.tsx
@@ -1,0 +1,357 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { css } from '@emotion/react';
+import { Drawer, Button, Modal, message } from 'antd';
+import { Save } from 'lucide-react';
+import { useTraceContext } from '../../context/TraceContext';
+import { InvocationEditor } from '../builder/InvocationEditor';
+import { RawJsonPreview } from './RawJsonPreview';
+import { readFileAsText } from '../../lib/utils';
+import { loadJaegerTraces } from '../../lib/trace-loader';
+import { convertTracesToInvocations } from '../../lib/trace-converter';
+import { parseTraceFileForEditing, buildEditMappings, applyEditsAndSerialize } from '../../lib/trace-patcher';
+import type { Invocation, ParsedTraceFile, SpanEditMapping } from '../../lib/types';
+
+interface TraceEditorDrawerProps {
+  file: File;
+  fileIndex: number;
+  open: boolean;
+  onClose: () => void;
+}
+
+interface TraceGroup {
+  traceId: string;
+  invocations: Invocation[];
+}
+
+export const TraceEditorDrawer: React.FC<TraceEditorDrawerProps> = ({ file, fileIndex, open, onClose }) => {
+  const { state, actions } = useTraceContext();
+  const [traceGroups, setTraceGroups] = useState<TraceGroup[]>([]);
+  const [parsedFile, setParsedFile] = useState<ParsedTraceFile | null>(null);
+  const [editMappings, setEditMappings] = useState<SpanEditMapping[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dirty, setDirty] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setLoading(true);
+    setError(null);
+    setDirty(false);
+
+    readFileAsText(file)
+      .then(async (content) => {
+        const parsed = parseTraceFileForEditing(content, file.name);
+        setParsedFile(parsed);
+
+        const traces = await loadJaegerTraces(content);
+        const conversionResults = convertTracesToInvocations(traces);
+        const mappings = buildEditMappings(traces, parsed);
+        setEditMappings(mappings);
+
+        const groups: TraceGroup[] = [];
+        for (const trace of traces) {
+          const result = conversionResults.get(trace.traceId);
+          if (result && result.invocations.length > 0) {
+            groups.push({ traceId: trace.traceId, invocations: result.invocations });
+          }
+        }
+        setTraceGroups(groups);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to parse trace file');
+        setLoading(false);
+      });
+  }, [file, open]);
+
+  const handleClose = useCallback(() => {
+    if (dirty) {
+      Modal.confirm({
+        title: 'Discard changes?',
+        content: 'You have unsaved changes that will be lost.',
+        okText: 'Discard',
+        okType: 'danger',
+        onOk: onClose,
+      });
+    } else {
+      onClose();
+    }
+  }, [dirty, onClose]);
+
+  const handleApply = useCallback(() => {
+    if (!parsedFile) return;
+
+    const allInvocations = traceGroups.flatMap(g => g.invocations);
+    const content = applyEditsAndSerialize(parsedFile, allInvocations, editMappings);
+    const newFile = new File([content], file.name, { type: 'application/octet-stream' });
+
+    const newFiles = [...state.traceFiles];
+    newFiles[fileIndex] = newFile;
+    actions.setTraceFiles(newFiles);
+
+    setDirty(false);
+    message.success('Trace file updated');
+    onClose();
+  }, [parsedFile, traceGroups, editMappings, file.name, fileIndex, state.traceFiles, actions, onClose]);
+
+  const handleInvocationChange = useCallback((traceIdx: number, invIdx: number, updated: Invocation) => {
+    setTraceGroups(prev => {
+      const newGroups = [...prev];
+      const group = { ...newGroups[traceIdx] };
+      const invs = [...group.invocations];
+      invs[invIdx] = updated;
+      group.invocations = invs;
+      newGroups[traceIdx] = group;
+      return newGroups;
+    });
+    setDirty(true);
+  }, []);
+
+  const previewContent = useMemo(() => {
+    if (!parsedFile || !dirty) return null;
+    const allInvocations = traceGroups.flatMap(g => g.invocations);
+    return applyEditsAndSerialize(parsedFile, allInvocations, editMappings);
+  }, [parsedFile, traceGroups, editMappings, dirty]);
+
+  const [initialContent, setInitialContent] = useState<string>('');
+  useEffect(() => {
+    if (open && parsedFile) {
+      if (parsedFile.format === 'otlp-jsonl') {
+        setInitialContent(parsedFile.rawData.map((line: any) => JSON.stringify(line)).join('\n'));
+      } else {
+        setInitialContent(JSON.stringify(parsedFile.rawData, null, 2));
+      }
+    }
+  }, [open, parsedFile]);
+
+  const totalInvocations = traceGroups.reduce((sum, g) => sum + g.invocations.length, 0);
+
+  return (
+    <Drawer
+      title={null}
+      placement="right"
+      width="85%"
+      open={open}
+      onClose={handleClose}
+      destroyOnClose
+      closable={false}
+      styles={{
+        header: { display: 'none' },
+        body: { padding: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--bg-primary)' },
+      }}
+    >
+      <div css={headerStyle}>
+        <div css={leftSectionStyle}>
+          <div css={titleStyle}>
+            <h1>Edit Trace</h1>
+            <span css={subtitleStyle}>{file.name}</span>
+          </div>
+          {dirty && <span css={unsavedBadgeStyle}>unsaved changes</span>}
+        </div>
+        <div css={rightSectionStyle}>
+          <Button css={cancelButtonStyle} onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button css={applyButtonStyle} type="primary" icon={<Save size={16} />} onClick={handleApply} disabled={!dirty || !parsedFile}>
+            Apply Changes
+          </Button>
+        </div>
+      </div>
+
+      {loading && (
+        <div css={centeredMessageStyle}>Loading trace data...</div>
+      )}
+
+      {error && (
+        <div css={css`${centeredMessageStyle}; color: var(--status-failure);`}>{error}</div>
+      )}
+
+      {!loading && !error && (
+        <div css={contentStyle}>
+          <div css={editorPanelStyle}>
+            {totalInvocations === 0 ? (
+              <div css={emptyMessageStyle}>
+                No invocations could be extracted from this trace file.
+              </div>
+            ) : (
+              traceGroups.map((group, gIdx) => (
+                <div key={group.traceId} style={{ marginBottom: gIdx < traceGroups.length - 1 ? 24 : 0 }}>
+                  {traceGroups.length > 1 && (
+                    <div css={traceIdBadgeStyle}>
+                      Trace: {group.traceId.substring(0, 16)}...
+                      <span css={traceIdCountStyle}>
+                        ({group.invocations.length} invocation{group.invocations.length !== 1 ? 's' : ''})
+                      </span>
+                    </div>
+                  )}
+                  <div css={sectionLabelStyle}>
+                    Invocations ({group.invocations.length})
+                  </div>
+                  {group.invocations.map((inv, iIdx) => (
+                    <InvocationEditor
+                      key={inv.invocationId}
+                      invocation={inv}
+                      onChange={(updated) => handleInvocationChange(gIdx, iIdx, updated)}
+                    />
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+          <div css={previewPanelStyle}>
+            <RawJsonPreview
+              content={previewContent || initialContent}
+              title="Trace File Preview"
+            />
+          </div>
+        </div>
+      )}
+    </Drawer>
+  );
+};
+
+const headerStyle = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+`;
+
+const leftSectionStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+const titleStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  h1 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+`;
+
+const subtitleStyle = css`
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-family: monospace;
+`;
+
+const unsavedBadgeStyle = css`
+  font-size: 0.7rem;
+  color: var(--status-warning);
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: rgba(245, 158, 11, 0.1);
+`;
+
+const rightSectionStyle = css`
+  display: flex;
+  gap: 12px;
+`;
+
+const cancelButtonStyle = css`
+  &.ant-btn {
+    background: transparent;
+    border-color: var(--border-default);
+    color: var(--text-secondary);
+
+    &:hover {
+      border-color: var(--text-secondary);
+      color: var(--text-primary);
+      background: rgba(255, 255, 255, 0.04);
+    }
+  }
+`;
+
+const applyButtonStyle = css`
+  &.ant-btn-primary {
+    background-color: var(--accent-primary);
+    border-color: var(--accent-primary);
+
+    &:hover {
+      background-color: var(--accent-primary);
+      border-color: var(--accent-primary);
+      opacity: 0.85;
+    }
+
+    &:disabled {
+      background-color: rgba(168, 85, 247, 0.3);
+      border-color: transparent;
+      color: rgba(255, 255, 255, 0.4);
+    }
+  }
+`;
+
+const contentStyle = css`
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
+`;
+
+const editorPanelStyle = css`
+  width: 50%;
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: 24px;
+`;
+
+const previewPanelStyle = css`
+  width: 50%;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  overflow-y: auto;
+`;
+
+const centeredMessageStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 48px;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+`;
+
+const emptyMessageStyle = css`
+  text-align: center;
+  padding: 40px;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+`;
+
+const traceIdBadgeStyle = css`
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+  padding: 6px 10px;
+  background: var(--bg-surface);
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+  font-family: monospace;
+`;
+
+const traceIdCountStyle = css`
+  font-weight: 400;
+  margin-left: 8px;
+`;
+
+const sectionLabelStyle = css`
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+`;

--- a/ui/src/components/upload/UploadView.tsx
+++ b/ui/src/components/upload/UploadView.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, Select, Slider } from 'antd';
 import { css } from '@emotion/react';
-import { Play } from 'lucide-react';
+import { Play, Pencil } from 'lucide-react';
 import { FileDropZone } from './FileDropZone';
 import { MetricSelector } from './MetricSelector';
+import { EvalSetEditorDrawer } from './EvalSetEditorDrawer';
+import { TraceEditorDrawer } from './TraceEditorDrawer';
 import { useTraceContext } from '../../context/TraceContext';
 
 const uploadViewStyle = css`
@@ -183,6 +185,8 @@ type JudgeModelProvider = typeof JUDGE_MODELS[number]['provider'];
 
 export const UploadView: React.FC = () => {
   const { state, actions } = useTraceContext();
+  const [evalSetDrawerOpen, setEvalSetDrawerOpen] = useState(false);
+  const [traceEditorIndex, setTraceEditorIndex] = useState<number | null>(null);
 
   const canRunEvaluation =
     state.traceFiles.length > 0 &&
@@ -228,6 +232,7 @@ export const UploadView: React.FC = () => {
                 {state.traceFiles.map((file, idx) => (
                   <div
                     key={idx}
+                    onClick={() => setTraceEditorIndex(idx)}
                     style={{
                       color: 'var(--text-secondary)',
                       fontSize: '11px',
@@ -235,10 +240,18 @@ export const UploadView: React.FC = () => {
                       backgroundColor: 'var(--bg-surface)',
                       borderRadius: '3px',
                       marginTop: idx > 0 ? '3px' : '0',
-                      fontFamily: 'monospace'
+                      fontFamily: 'monospace',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      transition: 'background 0.15s ease',
                     }}
+                    onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-elevated)'; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.background = 'var(--bg-surface)'; }}
                   >
                     {file.name}
+                    <Pencil size={10} style={{ opacity: 0.4, flexShrink: 0 }} />
                   </div>
                 ))}
                 {state.isLoadingMetadata && (
@@ -284,15 +297,26 @@ export const UploadView: React.FC = () => {
                   <div style={{ color: 'var(--text-primary)', fontSize: '12px', fontWeight: 600, marginBottom: '6px' }}>
                     Eval set file:
                   </div>
-                  <div style={{
-                    color: 'var(--text-secondary)',
-                    fontSize: '11px',
-                    padding: '3px 6px',
-                    backgroundColor: 'var(--bg-surface)',
-                    borderRadius: '3px',
-                    fontFamily: 'monospace'
-                  }}>
+                  <div
+                    onClick={() => setEvalSetDrawerOpen(true)}
+                    style={{
+                      color: 'var(--text-secondary)',
+                      fontSize: '11px',
+                      padding: '3px 6px',
+                      backgroundColor: 'var(--bg-surface)',
+                      borderRadius: '3px',
+                      fontFamily: 'monospace',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      transition: 'background 0.15s ease',
+                    }}
+                    onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-elevated)'; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.background = 'var(--bg-surface)'; }}
+                  >
                     {state.evalSetFile.name}
+                    <Pencil size={10} style={{ opacity: 0.4, flexShrink: 0 }} />
                   </div>
                 </div>
               ) : (
@@ -331,6 +355,7 @@ export const UploadView: React.FC = () => {
                   {state.traceFiles.map((file, idx) => (
                     <div
                       key={idx}
+                      onClick={() => setTraceEditorIndex(idx)}
                       style={{
                         color: 'var(--text-secondary)',
                         fontSize: '11px',
@@ -338,10 +363,18 @@ export const UploadView: React.FC = () => {
                         backgroundColor: 'var(--bg-surface)',
                         borderRadius: '3px',
                         marginTop: idx > 0 ? '3px' : '0',
-                        fontFamily: 'monospace'
+                        fontFamily: 'monospace',
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        transition: 'background 0.15s ease',
                       }}
+                      onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-elevated)'; }}
+                      onMouseLeave={(e) => { e.currentTarget.style.background = 'var(--bg-surface)'; }}
                     >
                       {file.name}
+                      <Pencil size={10} style={{ opacity: 0.4, flexShrink: 0 }} />
                     </div>
                   ))}
                   {state.isLoadingMetadata && (
@@ -399,15 +432,26 @@ export const UploadView: React.FC = () => {
                   }}>
                     Eval set file:
                   </div>
-                  <div style={{
-                    color: 'var(--text-secondary)',
-                    fontSize: '11px',
-                    padding: '3px 6px',
-                    backgroundColor: 'var(--bg-surface)',
-                    borderRadius: '3px',
-                    fontFamily: 'monospace'
-                  }}>
+                  <div
+                    onClick={() => setEvalSetDrawerOpen(true)}
+                    style={{
+                      color: 'var(--text-secondary)',
+                      fontSize: '11px',
+                      padding: '3px 6px',
+                      backgroundColor: 'var(--bg-surface)',
+                      borderRadius: '3px',
+                      fontFamily: 'monospace',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      transition: 'background 0.15s ease',
+                    }}
+                    onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-elevated)'; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.background = 'var(--bg-surface)'; }}
+                  >
                     {state.evalSetFile.name}
+                    <Pencil size={10} style={{ opacity: 0.4, flexShrink: 0 }} />
                   </div>
                 </div>
               )}
@@ -501,6 +545,23 @@ export const UploadView: React.FC = () => {
             : 'Run Evaluation'}
         </Button>
       </div>
+
+      {state.evalSetFile && (
+        <EvalSetEditorDrawer
+          file={state.evalSetFile}
+          open={evalSetDrawerOpen}
+          onClose={() => setEvalSetDrawerOpen(false)}
+        />
+      )}
+
+      {traceEditorIndex !== null && state.traceFiles[traceEditorIndex] && (
+        <TraceEditorDrawer
+          file={state.traceFiles[traceEditorIndex]}
+          fileIndex={traceEditorIndex}
+          open={true}
+          onClose={() => setTraceEditorIndex(null)}
+        />
+      )}
     </div>
   );
 };

--- a/ui/src/lib/trace-converter.ts
+++ b/ui/src/lib/trace-converter.ts
@@ -1,7 +1,7 @@
 import type { Trace, Span, Invocation, Content, ToolCall, ToolResponse, IntermediateData } from './types';
 import { safeJsonParse } from './utils';
 
-const ADK_SCOPE = 'gcp.vertex.agent';
+export const ADK_SCOPE = 'gcp.vertex.agent';
 
 export const USER_ROLES = ['user', 'human'];
 export const ASSISTANT_ROLES = ['assistant', 'model', 'ai'];
@@ -23,7 +23,7 @@ interface ConversionResult {
   warnings: string[];
 }
 
-function detectTraceFormat(trace: Trace): 'adk' | 'genai' {
+export function detectTraceFormat(trace: Trace): 'adk' | 'genai' {
   const check = (spans: Span[]): 'adk' | 'genai' | null => {
     let hasGenai = false;
     for (const span of spans) {
@@ -106,7 +106,7 @@ function convertADKTrace(trace: Trace): ConversionResult {
  * Recursively find child spans by operation name prefix
  * (replicates Python's _find_children_by_op)
  */
-function findChildrenByOperation(root: Span, opPrefix: string): Span[] {
+export function findChildrenByOperation(root: Span, opPrefix: string): Span[] {
   const results: Span[] = [];
   walkSpanTree(root, opPrefix, results);
   results.sort((a, b) => a.startTime - b.startTime);
@@ -568,7 +568,7 @@ function convertGenAIRootSpan(rootSpan: Span, _trace: Trace): Invocation | null 
   };
 }
 
-function findDescendantLLMSpans(root: Span): Span[] {
+export function findDescendantLLMSpans(root: Span): Span[] {
   const results: Span[] = [];
   const queue = [root];
 

--- a/ui/src/lib/trace-patcher.ts
+++ b/ui/src/lib/trace-patcher.ts
@@ -1,0 +1,328 @@
+import type { Trace, Span, Invocation, ParsedTraceFile, SpanEditMapping, SpanLocationRef } from './types';
+import {
+  ADK_SCOPE,
+  detectTraceFormat,
+  findChildrenByOperation,
+  findDescendantLLMSpans,
+  USER_ROLES,
+  ASSISTANT_ROLES,
+} from './trace-converter';
+
+export function parseTraceFileForEditing(content: string, fileName: string): ParsedTraceFile {
+  const trimmed = content.trim();
+  const isOtlpJsonl = detectOtlpJsonl(trimmed);
+
+  if (isOtlpJsonl) {
+    return parseOtlpJsonl(trimmed, fileName);
+  }
+  return parseJaegerJson(trimmed, fileName);
+}
+
+function detectOtlpJsonl(content: string): boolean {
+  if (!content.includes('\n') || content.startsWith('[')) return false;
+  try {
+    const firstLine = content.split('\n')[0].trim();
+    const parsed = JSON.parse(firstLine);
+    return !('data' in parsed);
+  } catch {
+    return false;
+  }
+}
+
+function parseOtlpJsonl(content: string, fileName: string): ParsedTraceFile {
+  const lines = content.split('\n').filter(l => l.trim());
+  const rawData = lines.map(line => JSON.parse(line));
+  const spanIndex = new Map<string, SpanLocationRef>();
+
+  rawData.forEach((span, lineIndex) => {
+    if (span.spanId) {
+      spanIndex.set(span.spanId, { lineIndex });
+    }
+  });
+
+  return { format: 'otlp-jsonl', fileName, rawData, spanIndex };
+}
+
+function parseJaegerJson(content: string, fileName: string): ParsedTraceFile {
+  const rawData = JSON.parse(content);
+  const spanIndex = new Map<string, SpanLocationRef>();
+
+  if (rawData.data && Array.isArray(rawData.data)) {
+    rawData.data.forEach((trace: any, traceIndex: number) => {
+      if (trace.spans && Array.isArray(trace.spans)) {
+        trace.spans.forEach((span: any, spanIdx: number) => {
+          if (span.spanID) {
+            spanIndex.set(span.spanID, { traceIndex, spanIndex: spanIdx });
+          }
+        });
+      }
+    });
+  }
+
+  return { format: 'jaeger', fileName, rawData, spanIndex };
+}
+
+export function buildEditMappings(traces: Trace[], _parsedFile: ParsedTraceFile): SpanEditMapping[] {
+  const mappings: SpanEditMapping[] = [];
+
+  for (const trace of traces) {
+    const format = detectTraceFormat(trace);
+
+    if (format === 'adk') {
+      mappings.push(...buildAdkMappings(trace));
+    } else {
+      mappings.push(...buildGenAIMappings(trace));
+    }
+  }
+
+  return mappings;
+}
+
+function buildAdkMappings(trace: Trace): SpanEditMapping[] {
+  const mappings: SpanEditMapping[] = [];
+
+  const agentSpans = trace.allSpans.filter(
+    (span) =>
+      span.operationName.includes('invoke_agent') &&
+      span.tags['otel.scope.name'] === ADK_SCOPE
+  );
+
+  for (const agentSpan of agentSpans) {
+    const llmSpans = findChildrenByOperation(agentSpan, 'call_llm');
+    const toolSpans = findChildrenByOperation(agentSpan, 'execute_tool');
+
+    if (llmSpans.length === 0) continue;
+
+    mappings.push({
+      invocationId: agentSpan.spanId,
+      format: 'adk',
+      userInputSpanId: llmSpans[0].spanId,
+      finalResponseSpanId: llmSpans[llmSpans.length - 1].spanId,
+      toolSpanIds: toolSpans.map(s => s.spanId),
+      userInputAttrKey: 'gcp.vertex.agent.llm_request',
+      finalResponseAttrKey: 'gcp.vertex.agent.llm_response',
+    });
+  }
+
+  return mappings;
+}
+
+function buildGenAIMappings(trace: Trace): SpanEditMapping[] {
+  const mappings: SpanEditMapping[] = [];
+
+  const llmRootSpans = trace.rootSpans.filter(span =>
+    span.tags['gen_ai.request.model'] || span.tags['gen_ai.system']
+  );
+
+  const rootSpansToCheck = llmRootSpans.length > 0
+    ? llmRootSpans
+    : trace.rootSpans.slice(0, 1);
+
+  for (const rootSpan of rootSpansToCheck) {
+    const llmSpans = findDescendantLLMSpans(rootSpan);
+    if (llmSpans.length === 0) continue;
+
+    const firstLlm = llmSpans[0];
+    const lastLlm = llmSpans[llmSpans.length - 1];
+
+    const userInputAttrKey = resolveInputAttrKey(firstLlm);
+    const finalResponseAttrKey = resolveOutputAttrKey(lastLlm);
+
+    if (!userInputAttrKey || !finalResponseAttrKey) continue;
+
+    mappings.push({
+      invocationId: rootSpan.spanId,
+      format: 'genai',
+      userInputSpanId: firstLlm.spanId,
+      finalResponseSpanId: lastLlm.spanId,
+      toolSpanIds: [],
+      userInputAttrKey,
+      finalResponseAttrKey,
+    });
+  }
+
+  return mappings;
+}
+
+function resolveInputAttrKey(span: Span): string | null {
+  if (span.tags['gen_ai.input.messages']) return 'gen_ai.input.messages';
+  if (span.tags['gen_ai.prompt']) return 'gen_ai.prompt';
+  if (span.tags['gen_ai.request.messages']) return 'gen_ai.request.messages';
+  return null;
+}
+
+function resolveOutputAttrKey(span: Span): string | null {
+  if (span.tags['gen_ai.output.messages']) return 'gen_ai.output.messages';
+  if (span.tags['gen_ai.completion']) return 'gen_ai.completion';
+  if (span.tags['gen_ai.response.messages']) return 'gen_ai.response.messages';
+  return null;
+}
+
+export function applyEditsAndSerialize(
+  parsedFile: ParsedTraceFile,
+  invocations: Invocation[],
+  editMappings: SpanEditMapping[]
+): string {
+  const mappingByInvId = new Map(editMappings.map(m => [m.invocationId, m]));
+
+  for (const inv of invocations) {
+    const mapping = mappingByInvId.get(inv.invocationId);
+    if (!mapping) continue;
+
+    const userText = inv.userContent?.parts?.[0]?.text;
+    const responseText = inv.finalResponse?.parts?.[0]?.text;
+
+    if (userText !== undefined) {
+      patchAttribute(parsedFile, mapping.userInputSpanId, mapping.userInputAttrKey, mapping.format, 'user', userText);
+    }
+    if (responseText !== undefined) {
+      patchAttribute(parsedFile, mapping.finalResponseSpanId, mapping.finalResponseAttrKey, mapping.format, 'response', responseText);
+    }
+  }
+
+  return serialize(parsedFile);
+}
+
+function patchAttribute(
+  parsedFile: ParsedTraceFile,
+  spanId: string,
+  attrKey: string,
+  format: 'adk' | 'genai',
+  field: 'user' | 'response',
+  newText: string
+): void {
+  const locRef = parsedFile.spanIndex.get(spanId);
+  if (!locRef) return;
+
+  if (parsedFile.format === 'otlp-jsonl') {
+    patchOtlpAttribute(parsedFile.rawData[locRef.lineIndex!], attrKey, format, field, newText);
+  } else {
+    const span = parsedFile.rawData.data[locRef.traceIndex!].spans[locRef.spanIndex!];
+    patchJaegerAttribute(span, attrKey, format, field, newText);
+  }
+}
+
+function patchOtlpAttribute(
+  rawSpan: any,
+  attrKey: string,
+  format: 'adk' | 'genai',
+  field: 'user' | 'response',
+  newText: string
+): void {
+  const attrs = rawSpan.attributes;
+  if (!Array.isArray(attrs)) return;
+
+  const attr = attrs.find((a: any) => a.key === attrKey);
+  if (!attr?.value?.stringValue) return;
+
+  const patched = patchJsonValue(attr.value.stringValue, format, field, newText);
+  if (patched !== null) {
+    attr.value.stringValue = patched;
+  }
+}
+
+function patchJaegerAttribute(
+  rawSpan: any,
+  attrKey: string,
+  format: 'adk' | 'genai',
+  field: 'user' | 'response',
+  newText: string
+): void {
+  const tags = rawSpan.tags;
+  if (!Array.isArray(tags)) return;
+
+  const tag = tags.find((t: any) => t.key === attrKey);
+  if (!tag) return;
+
+  const patched = patchJsonValue(tag.value, format, field, newText);
+  if (patched !== null) {
+    tag.value = patched;
+  }
+}
+
+function patchJsonValue(
+  jsonStr: string,
+  format: 'adk' | 'genai',
+  field: 'user' | 'response',
+  newText: string
+): string | null {
+  try {
+    const data = JSON.parse(jsonStr);
+
+    if (format === 'adk') {
+      return patchAdkJsonValue(data, field, newText);
+    } else {
+      return patchGenAIJsonValue(data, field, newText);
+    }
+  } catch {
+    return null;
+  }
+}
+
+function patchAdkJsonValue(data: any, field: 'user' | 'response', newText: string): string {
+  if (field === 'user') {
+    const contents = data.contents;
+    if (Array.isArray(contents)) {
+      for (let i = contents.length - 1; i >= 0; i--) {
+        if (contents[i].role === 'user') {
+          const textParts = contents[i].parts?.filter((p: any) => p.text !== undefined);
+          if (textParts && textParts.length > 0) {
+            textParts[0].text = newText;
+            break;
+          }
+        }
+      }
+    }
+  } else {
+    const parts = data.content?.parts;
+    if (Array.isArray(parts)) {
+      const textParts = parts.filter((p: any) => p.text !== undefined);
+      if (textParts.length > 0) {
+        textParts[0].text = newText;
+      }
+    }
+  }
+
+  return JSON.stringify(data);
+}
+
+function patchGenAIJsonValue(data: any, field: 'user' | 'response', newText: string): string {
+  if (!Array.isArray(data)) return JSON.stringify(data);
+
+  const targetRoles = field === 'user' ? USER_ROLES : ASSISTANT_ROLES;
+
+  for (let i = data.length - 1; i >= 0; i--) {
+    const msg = data[i];
+    if (!targetRoles.includes(msg.role)) continue;
+
+    if (typeof msg.content === 'string') {
+      msg.content = newText;
+      break;
+    }
+    if (Array.isArray(msg.content)) {
+      const textItem = msg.content.find((item: any) => typeof item === 'object' && item.text);
+      if (textItem) {
+        textItem.text = newText;
+        break;
+      }
+    }
+    if (Array.isArray(msg.parts)) {
+      const textPart = msg.parts.find((p: any) => typeof p === 'object' && p.type === 'text');
+      if (textPart) {
+        textPart.content = newText;
+        break;
+      }
+    }
+    msg.content = newText;
+    break;
+  }
+
+  return JSON.stringify(data);
+}
+
+function serialize(parsedFile: ParsedTraceFile): string {
+  if (parsedFile.format === 'otlp-jsonl') {
+    return parsedFile.rawData.map((line: any) => JSON.stringify(line)).join('\n');
+  }
+  return JSON.stringify(parsedFile.rawData, null, 2);
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -357,6 +357,32 @@ export interface InspectorUIState {
   selectedInvocationId: string | null;
 }
 
+// Trace editor types
+export type TraceFileFormat = 'jaeger' | 'otlp-jsonl';
+
+export interface SpanLocationRef {
+  traceIndex?: number;
+  spanIndex?: number;
+  lineIndex?: number;
+}
+
+export interface ParsedTraceFile {
+  format: TraceFileFormat;
+  fileName: string;
+  rawData: any;
+  spanIndex: Map<string, SpanLocationRef>;
+}
+
+export interface SpanEditMapping {
+  invocationId: string;
+  format: 'adk' | 'genai';
+  userInputSpanId: string;
+  finalResponseSpanId: string;
+  toolSpanIds: string[];
+  userInputAttrKey: string;
+  finalResponseAttrKey: string;
+}
+
 // Annotation queue types
 export type FirstPassLabel = 'looks_correct' | 'doesnt_look_correct';
 

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -170,6 +170,40 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   }
 }
 
+export function convertSnakeToCamel(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map(convertSnakeToCamel);
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    const converted: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      const camelKey = key.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+      converted[camelKey] = convertSnakeToCamel(value);
+    }
+    return converted;
+  }
+
+  return obj;
+}
+
+export function convertCamelToSnake(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map(convertCamelToSnake);
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    const converted: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      const snakeKey = key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+      converted[snakeKey] = convertCamelToSnake(value);
+    }
+    return converted;
+  }
+
+  return obj;
+}
+
 /**
  * Get color for extraction type
  */


### PR DESCRIPTION
This PR adds new drawers so uploaded/streamed traces and EvalSets can be edited (except for tool calls, that comes later) from the UI.