### PR TITLE
add OpenAI Agents SDK zero-code example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.5.3] - 2026-03-29
+
+### Added
+- **OpenAI Agents SDK zero-code example** (`examples/zero-code-examples/openai-agents/`): a self-contained dice-rolling agent that demonstrates zero-code OTLP integration with the OpenAI Agents SDK (`openai-agents>=0.3.3`) via `opentelemetry-instrumentation-openai-agents-v2`. Includes `run.py`, `requirements.txt`, and a golden `eval_set.json` with a multi-turn conversation case.
+- **E2E integration tests** for the OpenAI Agents SDK example (`TestOpenAIAgentsZeroCode` in `tests/integration/test_live_agents.py`): verifies session creation, span emission, invocation extraction, and API visibility.
+
+### Fixed
+- Conversation context threading in `run.py` now uses `result.to_input_list()` (the SDK-idiomatic pattern) instead of manually appending raw role/content dicts, ensuring tool call history is preserved across turns.
+- `force_flush()` is now called in a `try/finally` block, guaranteeing spans are sent to the OTLP receiver even when an API error occurs mid-conversation.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,7 @@
+# TODOs
+
+## Eval set schema migration
+- **What:** Update `examples/langchain_agent/eval_set.json` and `examples/strands_agent/eval_set.json` to use documented schema (`eval_id`/`final_response`) instead of stale format (`case_id`/`agent_content`).
+- **Why:** The new openai-agents eval set uses the correct format. Without this fix, the langchain/strands examples become the odd ones out and teach new contributors the wrong pattern.
+- **Context:** Discovered during openai-agents zero-code integration review (2026-03-29). Schema loader likely accepts both formats so no behavior change. Reference: `docs/eval-set-format.md`, `samples/eval_set_helm.json` (already correct).
+- **Blocked by:** Nothing. Two-line JSON key rename per file.

--- a/examples/zero-code-examples/openai-agents/eval_set.json
+++ b/examples/zero-code-examples/openai-agents/eval_set.json
@@ -1,0 +1,91 @@
+{
+  "eval_set_id": "openai_agents_eval",
+  "name": "OpenAI Agents Dice Agent Eval Set",
+  "description": "Golden eval cases for the OpenAI Agents SDK zero-code example. One multi-turn session covering greeting, die roll, and prime check.",
+  "eval_cases": [
+    {
+      "eval_id": "dice-roll-session",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {"text": "Hi! Can you help me?"}
+            ]
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {"text": "Hello! Yes, I can help you. I have tools that can roll dice and check if numbers are prime. What would you like me to do?"}
+            ]
+          }
+        },
+        {
+          "invocation_id": "inv-2",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {"text": "Roll a 20-sided die for me"}
+            ]
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {"text": "I rolled a 20-sided die and got [number]. Let me know if you'd like to check if it's prime!"}
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "name": "roll_die",
+                "args": {"sides": 20},
+                "id": "call_roll_die_1"
+              }
+            ],
+            "tool_responses": [
+              {
+                "name": "roll_die",
+                "response": {
+                  "content": [{"type": "text", "text": "[number]"}]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "invocation_id": "inv-3",
+          "user_content": {
+            "role": "user",
+            "parts": [
+              {"text": "Is the number you rolled prime?"}
+            ]
+          },
+          "final_response": {
+            "role": "model",
+            "parts": [
+              {"text": "[number] is [prime/not prime]."}
+            ]
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "name": "check_prime",
+                "args": {"number": 0},
+                "id": "call_check_prime_1"
+              }
+            ],
+            "tool_responses": [
+              {
+                "name": "check_prime",
+                "response": {
+                  "content": [{"type": "text", "text": "[true/false]"}]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/examples/zero-code-examples/openai-agents/requirements.txt
+++ b/examples/zero-code-examples/openai-agents/requirements.txt
@@ -1,0 +1,6 @@
+openai-agents>=0.3.3
+opentelemetry-instrumentation-openai-agents-v2>=0.1.0
+
+opentelemetry-sdk>=1.36.0
+opentelemetry-exporter-otlp-proto-http>=1.36.0
+python-dotenv>=1.0.0

--- a/examples/zero-code-examples/openai-agents/run.py
+++ b/examples/zero-code-examples/openai-agents/run.py
@@ -1,0 +1,143 @@
+"""Run a dice-rolling OpenAI Agents SDK agent with OTLP export — no agentevals SDK.
+
+Demonstrates zero-code integration: any OTel-instrumented agent streams
+traces to agentevals by pointing the OTLP exporter at the receiver.
+
+Unlike the LangChain and Strands examples, this one is fully self-contained:
+the agent code lives inline with no cross-folder imports.
+
+Prerequisites:
+    1. pip install -r requirements.txt
+    2. agentevals serve --dev
+    3. export OPENAI_API_KEY="your-key-here"
+
+Usage:
+    python examples/zero-code-examples/openai-agents/run.py
+"""
+
+import os
+import random
+
+from agents import Agent, Runner, function_tool
+from dotenv import load_dotenv
+from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+load_dotenv(override=True)
+
+
+# ── Tool definitions ──────────────────────────────────────────────────────────
+
+@function_tool
+def roll_die(sides: int) -> int:
+    """Roll a die with the given number of sides and return the result."""
+    return random.randint(1, sides)
+
+
+@function_tool
+def check_prime(number: int) -> bool:
+    """Return True if the number is prime, False otherwise."""
+    if number < 2:
+        return False
+    for i in range(2, int(number**0.5) + 1):
+        if number % i == 0:
+            return False
+    return True
+
+
+def main():
+    if not os.getenv("OPENAI_API_KEY"):
+        print("OPENAI_API_KEY not set.")
+        return
+
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+    print(f"OTLP endpoint: {endpoint}")
+
+    # openai-agents-v2 uses ContentCaptureMode — use "span_and_event" for maximum
+    # content capture. agentevals reads from span attributes, so content will be
+    # visible in the UI.
+    os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "span_and_event"
+
+    os.environ.setdefault(
+        "OTEL_RESOURCE_ATTRIBUTES",
+        "agentevals.eval_set_id=openai_agents_eval,agentevals.session_name=openai-agents-zero-code",
+    )
+
+    # OTel setup flow:
+    #
+    #   Resource (session/eval attrs)
+    #       │
+    #       ├── TracerProvider → BatchSpanProcessor → OTLPSpanExporter → :4318
+    #       │
+    #       └── LoggerProvider → BatchLogRecordProcessor → OTLPLogExporter → :4318
+    #           (openai-agents-v2 may route message content to span attributes
+    #            rather than log records; OTLPLogExporter is a no-op if unused)
+    #
+    #   OpenAIAgentsInstrumentor.instrument()
+    #       └── hooks into agents SDK → emits spans + (optionally) log records
+    #
+    #   Runner.run_sync(agent, input)  ← called with accumulated conversation
+
+    resource = Resource.create()
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(), schedule_delay_millis=1000))
+    trace.set_tracer_provider(tracer_provider)
+
+    logger_provider = LoggerProvider(resource=resource)
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter(), schedule_delay_millis=1000))
+    set_logger_provider(logger_provider)
+
+    OpenAIAgentsInstrumentor().instrument()
+
+    agent = Agent(
+        name="Dice Agent",
+        instructions="You are a helpful assistant. You can roll dice and check if numbers are prime.",
+        tools=[roll_die, check_prime],
+    )
+
+    test_queries = [
+        "Hi! Can you help me?",
+        "Roll a 20-sided die for me",
+        "Is the number you rolled prime?",
+    ]
+
+    # Accumulate conversation context so turn 3 ("Is it prime?") can reference
+    # the number rolled in turn 2. openai-agents Runner.run_sync() is stateless
+    # per call, so we thread prior messages via result.to_input_list() — the SDK's
+    # canonical way to carry full response history (tool calls, tool results, etc.)
+    # into the next turn. Raw role/content dicts can silently drop tool-call context.
+    conversation_input: list = []
+
+    try:
+        for i, query in enumerate(test_queries, 1):
+            print(f"\n[{i}/{len(test_queries)}] User: {query}")
+
+            conversation_input.append({"role": "user", "content": query})
+            result = Runner.run_sync(agent, conversation_input)
+
+            agent_response = result.final_output or ""
+            print(f"     Agent: {agent_response}")
+
+            # to_input_list() returns the full turn history including tool calls and
+            # results, which is what the SDK expects as input for the next turn.
+            conversation_input = result.to_input_list()
+    finally:
+        # Always flush — even if a turn raises (rate limit, network error, etc.)
+        # so that whatever spans were recorded make it to the OTLP receiver.
+        print()
+        tracer_provider.force_flush()
+        logger_provider.force_flush()
+        print("All traces and logs flushed to OTLP receiver.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentevals-cli"
-version = "0.5.2"
+version = "0.5.3"
 description = "Standalone framework to evaluate agent correctness based on portable OpenTelemetry traces"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/integration/test_live_agents.py
+++ b/tests/integration/test_live_agents.py
@@ -249,6 +249,63 @@ class TestAdkZeroCode:
 
 
 @_skip_no_openai
+class TestOpenAIAgentsZeroCode:
+    """Run the OpenAI Agents SDK zero-code OTLP example and verify session grouping."""
+
+    def test_session_created_with_spans(self, live_servers):
+        main_port, otlp_port, mgr = live_servers
+        session_name = "e2e-openai-agents"
+
+        result = _run_agent(
+            "examples/zero-code-examples/openai-agents/run.py",
+            otlp_port,
+            session_name,
+        )
+        assert result.returncode == 0, f"Agent failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+
+        wait_for_session_complete_sync(mgr, session_name, timeout=30)
+        session = mgr.sessions[session_name]
+
+        assert session.is_complete
+        assert session.source == "otlp"
+        assert len(session.spans) > 0, "Expected spans from LLM calls"
+
+    def test_invocations_extracted(self, live_servers):
+        main_port, otlp_port, mgr = live_servers
+        session_name = "e2e-openai-agents-inv"
+
+        result = _run_agent(
+            "examples/zero-code-examples/openai-agents/run.py",
+            otlp_port,
+            session_name,
+        )
+        assert result.returncode == 0, f"Agent failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+
+        wait_for_session_complete_sync(mgr, session_name, timeout=30)
+        session = mgr.sessions[session_name]
+
+        assert len(session.invocations) > 0, "Expected extracted invocations"
+
+    def test_session_visible_via_api(self, live_servers):
+        main_port, otlp_port, mgr = live_servers
+        session_name = "e2e-openai-agents-api"
+
+        result = _run_agent(
+            "examples/zero-code-examples/openai-agents/run.py",
+            otlp_port,
+            session_name,
+        )
+        assert result.returncode == 0
+
+        wait_for_session_complete_sync(mgr, session_name, timeout=30)
+
+        resp = httpx.get(f"http://127.0.0.1:{main_port}/api/streaming/sessions")
+        assert resp.status_code == 200
+        session_ids = [s["sessionId"] for s in resp.json()["data"]]
+        assert session_name in session_ids
+
+
+@_skip_no_openai
 class TestAgentRerun:
     """Verify that re-running an agent with the same session_name creates
     separate sessions, not merging them into one.


### PR DESCRIPTION
## Summary

- Adds `examples/zero-code-examples/openai-agents/` — a self-contained dice-rolling agent showing zero-code OTLP integration with `openai-agents>=0.3.3` via `opentelemetry-instrumentation-openai-agents-v2`
- Adds `TestOpenAIAgentsZeroCode` e2e tests verifying session creation, span emission, invocation extraction, and API visibility
- Adds `CHANGELOG.md` (first entry) and `TODOS.md` (schema migration note for langchain/strands eval sets)

## Implementation notes

- Uses `result.to_input_list()` for conversation context threading (not raw role/content dicts) — the SDK-idiomatic pattern that preserves tool call history across turns
- `force_flush()` is called in `try/finally`, guaranteeing spans reach the OTLP receiver even on API errors mid-conversation
- OTel setup matches the pattern from other zero-code examples: TracerProvider + LoggerProvider, both pointing to `OTEL_EXPORTER_OTLP_ENDPOINT`, with `BatchSpanProcessor`/`BatchLogRecordProcessor` flushed at end of run
- `eval_set.json` uses the documented schema (`eval_id`/`final_response`) with a single multi-turn case covering all 3 turns (greeting, die roll, prime check)

## Test plan

- [ ] `OPENAI_API_KEY` set: run `python examples/zero-code-examples/openai-agents/run.py` and verify 3 turns complete and traces appear in the UI
- [ ] E2e tests pass: `pytest tests/integration/ -m e2e -k openai_agents` with `OPENAI_API_KEY` set
- [ ] Non-e2e integration tests pass: `pytest tests/integration/ -m "not e2e"` (28 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)