### PR TITLE
Improve nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768818222,
-        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -102,7 +82,6 @@
     },
     "root": {
       "inputs": {
-        "devshell": "devshell",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "pyproject-build-systems": "pyproject-build-systems",

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils = {
-      url = "github:numtide/flake-utils";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    flake-utils.url = "github:numtide/flake-utils";
     pyproject-nix = {
       url = "github:pyproject-nix/pyproject.nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -22,10 +19,6 @@
       inputs.uv2nix.follows = "uv2nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    devshell = {
-      url = "github:numtide/devshell";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
@@ -38,25 +31,27 @@
       system:
       let
         workspaceRoot = ./.;
-        venvName = "venv";
 
         pkgs = import nixpkgs {
           inherit system;
           config.allowUnfree = true;
         };
         python = pkgs.python314;
-        workspace = inputs.uv2nix.lib.workspace.loadWorkspace { workspaceRoot = workspaceRoot; };
+
+        workspace = inputs.uv2nix.lib.workspace.loadWorkspace { inherit workspaceRoot; };
         overlay = workspace.mkPyprojectOverlay {
           sourcePreference = "wheel";
         };
+
         # Fix rouge-score missing setuptools build dependency
         rougeScoreOverlay = final: prev: {
           rouge-score = prev.rouge-score.overrideAttrs (old: {
             nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.setuptools ];
           });
         };
+
         baseSet = pkgs.callPackage inputs.pyproject-nix.build.packages {
-          python = python;
+          inherit python;
         };
         pythonSet = baseSet.overrideScope (
           pkgs.lib.composeManyExtensions [
@@ -65,9 +60,22 @@
             rougeScoreOverlay
           ]
         );
-        venv = pythonSet.mkVirtualEnv "${venvName}" workspace.deps.default;
+
+        venv = pythonSet.mkVirtualEnv "agentevals-env" workspace.deps.default;
       in
       {
+        packages = {
+          default = venv;
+          agentevals-cli = pythonSet."agentevals-cli";
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${venv}/bin/agentevals";
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+
         devShells.default = pkgs.mkShell {
           packages = [
             # Base


### PR DESCRIPTION
This PR improves the flake.nix to follow best practices:

  - Removed unused devshell input
  - Fixed warning from flake-utils having a nixpkgs follows it doesn't need
  - Added packages.default (full venv) and packages.agentevals-cli (bare package) so nix build also works
  - Added apps.default so nix run . launches the CLI directly
  - Added formatter output for nix fmt support
  - Small Nix idiom cleanups

New capabilities:
  - `nix build`, produces a self-contained virtualenv with the agentevals CLI
  - `nix build .#agentevals-cli`, builds just the Python package
  - `nix run .`, runs agentevals directly
  - `nix fmt`, formats the flake with nixfmt-rfc-style
  - `nix develop`, same devShell as before