### PR TITLE
feat(metrics): add skills_trajectory_v1 evaluator

### DIFF
--- a/src/agentevals/api/routes.py
+++ b/src/agentevals/api/routes.py
@@ -17,7 +17,12 @@ from pydantic.alias_generators import to_camel
 
 from agentevals import __version__
 
-from ..builtin_metrics import METRICS_NEEDING_EXPECTED, METRICS_NEEDING_GCP, METRICS_NEEDING_LLM
+from ..builtin_metrics import (
+    METRICS_NEEDING_EXPECTED,
+    METRICS_NEEDING_GCP,
+    METRICS_NEEDING_LLM,
+    METRICS_SKILLS_TRAJECTORY,
+)
 from ..config import (
     BuiltinMetricDef,
     CodeEvaluatorDef,
@@ -118,6 +123,7 @@ async def list_metrics():
         "multi_turn_task_success_v1": "multi-turn",
         "multi_turn_trajectory_quality_v1": "multi-turn",
         "multi_turn_tool_use_quality_v1": "multi-turn",
+        METRICS_SKILLS_TRAJECTORY: "trajectory",
     }
 
     try:
@@ -144,6 +150,19 @@ async def list_metrics():
                     working=m.metric_name not in _METRICS_NEEDING_RUBRICS,
                 )
             )
+
+        metrics.append(
+            MetricInfo(
+                name=METRICS_SKILLS_TRAJECTORY,
+                category="trajectory",
+                requires_eval_set=False,
+                requires_llm=False,
+                requires_gcp=False,
+                requires_rubrics=False,
+                working=True,
+                description="Check whether specific skills (tools) were called, optionally in order",
+            )
+        )
 
         return StandardResponse(data=metrics)
 
@@ -258,6 +277,16 @@ async def list_metrics():
                 requires_rubrics=False,
                 working=True,
                 description="Evaluates function calls made during a multi-turn conversation (Vertex AI)",
+            ),
+            MetricInfo(
+                name=METRICS_SKILLS_TRAJECTORY,
+                category="trajectory",
+                requires_eval_set=False,
+                requires_llm=False,
+                requires_gcp=False,
+                requires_rubrics=False,
+                working=True,
+                description="Check whether specific skills (tools) were called, optionally in order",
             ),
         ]
         return StandardResponse(data=fallback)

--- a/src/agentevals/builtin_metrics.py
+++ b/src/agentevals/builtin_metrics.py
@@ -29,6 +29,8 @@ from google.adk.evaluation.evaluator import EvaluationResult, Evaluator
 
 logger = logging.getLogger(__name__)
 
+METRICS_SKILLS_TRAJECTORY = "skills_trajectory_v1"
+
 METRICS_NEEDING_EXPECTED = {
     "tool_trajectory_avg_score",
     "response_match_score",
@@ -298,6 +300,78 @@ def extract_trajectory_details(eval_result: EvaluationResult) -> dict[str, Any]:
     return {"comparisons": comparisons}
 
 
+def _evaluate_skills_trajectory(
+    actual_invocations: list[Invocation],
+    skills: list[str],
+    match_type: str | None,
+    threshold: float | None,
+) -> Any:
+    """Evaluate whether required skills (tool names) were called per invocation.
+
+    Score per invocation = fraction of required skills that were called.
+    match_type ``IN_ORDER`` additionally requires the skills appear in the given order.
+    """
+    from .runner import MetricResult
+
+    if not skills:
+        return MetricResult(
+            metric_name=METRICS_SKILLS_TRAJECTORY,
+            error="'skills' list is required for skills_trajectory_v1 but was empty.",
+        )
+
+    effective_threshold = threshold if threshold is not None else 0.5
+    order_matters = (match_type or "ANY_ORDER").upper() == "IN_ORDER"
+
+    per_inv_scores: list[float] = []
+    comparisons: list[dict[str, Any]] = []
+
+    for inv in actual_invocations:
+        called = [tc.name for tc in get_all_tool_calls(inv.intermediate_data)]
+        score = _skills_score(skills, called, order_matters)
+        per_inv_scores.append(score)
+        comparisons.append(
+            {
+                "invocation_id": inv.invocation_id or None,
+                "required_skills": skills,
+                "called_tools": called,
+                "score": score,
+            }
+        )
+
+    overall = sum(per_inv_scores) / len(per_inv_scores) if per_inv_scores else 0.0
+    status = "PASSED" if overall >= effective_threshold else "FAILED"
+
+    return MetricResult(
+        metric_name=METRICS_SKILLS_TRAJECTORY,
+        score=overall,
+        eval_status=status,
+        per_invocation_scores=per_inv_scores,
+        details={"comparisons": comparisons},
+    )
+
+
+def _skills_score(required: list[str], called: list[str], order_matters: bool) -> float:
+    """Return fraction of *required* skills satisfied in *called*, optionally in order."""
+    if not required:
+        return 1.0
+
+    if order_matters:
+        # Subsequence check: each required skill must appear after the previous one
+        pos = 0
+        hits = 0
+        for skill in required:
+            while pos < len(called):
+                if called[pos] == skill:
+                    hits += 1
+                    pos += 1
+                    break
+                pos += 1
+        return hits / len(required)
+
+    called_set = set(called)
+    return sum(1 for s in required if s in called_set) / len(required)
+
+
 async def evaluate_builtin_metric(
     metric_name: str,
     actual_invocations: list[Invocation],
@@ -305,6 +379,8 @@ async def evaluate_builtin_metric(
     judge_model: str | None,
     threshold: float | None,
     match_type: str | None = None,
+    skills: list[str] | None = None,
+    skills_match_type: str | None = None,
 ) -> dict[str, Any]:
     """Evaluate a single built-in ADK metric.
 
@@ -321,6 +397,9 @@ async def evaluate_builtin_metric(
                 f"(golden eval set), but none were provided or matched."
             ),
         )
+
+    if metric_name == METRICS_SKILLS_TRAJECTORY:
+        return _evaluate_skills_trajectory(actual_invocations, skills or [], skills_match_type, threshold)
 
     try:
         eval_metric = build_eval_metric(metric_name, judge_model, threshold, match_type=match_type)

--- a/src/agentevals/config.py
+++ b/src/agentevals/config.py
@@ -145,6 +145,24 @@ class EvalRunConfig(BaseModel):
             raise ValueError(f"Invalid trajectory_match_type '{v}'. Valid values: {sorted(valid)}")
         return v.upper() if v is not None else v
 
+    skills_trajectory_skills: list[str] = Field(
+        default_factory=list,
+        description="Required skill (tool) names for skills_trajectory_v1.",
+    )
+
+    skills_trajectory_match_type: str = Field(
+        default="ANY_ORDER",
+        description="Match type for skills_trajectory_v1: 'ANY_ORDER' or 'IN_ORDER'.",
+    )
+
+    @field_validator("skills_trajectory_match_type")
+    @classmethod
+    def _validate_skills_trajectory_match_type(cls, v: str) -> str:
+        valid = {"ANY_ORDER", "IN_ORDER"}
+        if v.upper() not in valid:
+            raise ValueError(f"Invalid skills_trajectory_match_type '{v}'. Valid values: {sorted(valid)}")
+        return v.upper()
+
     output_format: str = Field(
         default="table",
         description="Output format: 'table', 'json', or 'summary'.",

--- a/src/agentevals/runner.py
+++ b/src/agentevals/runner.py
@@ -141,6 +141,8 @@ async def run_evaluation(
                 judge_model=config.judge_model,
                 threshold=config.threshold,
                 trajectory_match_type=config.trajectory_match_type,
+                skills=config.skills_trajectory_skills,
+                skills_match_type=config.skills_trajectory_match_type,
                 eval_semaphore=eval_semaphore,
                 progress_callback=progress_callback,
                 trace_progress_callback=trace_progress_callback,
@@ -239,6 +241,8 @@ async def _evaluate_trace(
     trace=None,
     performance_metrics: dict[str, Any] | None = None,
     trajectory_match_type: str | None = None,
+    skills: list[str] | None = None,
+    skills_match_type: str | None = None,
 ) -> TraceResult:
     trace_result = TraceResult(
         trace_id=conv_result.trace_id,
@@ -282,6 +286,8 @@ async def _evaluate_trace(
                 judge_model=judge_model,
                 threshold=threshold,
                 match_type=trajectory_match_type,
+                skills=skills,
+                skills_match_type=skills_match_type,
             )
             result.duration_ms = (time.monotonic() - t0) * 1000
         return await _append_result(result)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -386,7 +386,7 @@ class TestMetricsEndpoint:
     def test_metrics_fallback(self):
         with patch.dict("sys.modules", {"google.adk.evaluation.metric_evaluator_registry": None}):
             body = _assert_envelope(self.client.get("/api/metrics"))
-        assert len(body["data"]) == 11
+        assert len(body["data"]) == 12
 
     def test_metrics_envelope(self):
         body = _assert_envelope(self.client.get("/api/metrics"))

--- a/tests/test_skills_evaluator.py
+++ b/tests/test_skills_evaluator.py
@@ -1,0 +1,412 @@
+"""Tests for the skills_trajectory_v1 evaluator."""
+
+import asyncio
+import json
+
+import pytest
+
+from agentevals.builtin_metrics import (
+    METRICS_SKILLS_TRAJECTORY,
+    _evaluate_skills_trajectory,
+    _skills_score,
+    evaluate_builtin_metric,
+)
+from agentevals.config import EvalRunConfig
+from agentevals.converter import convert_traces
+from agentevals.loader.base import Span, Trace
+from agentevals.runner import _evaluate_trace, run_evaluation
+
+
+def _make_trace(tools: list[str], trace_id: str = "t1") -> Trace:
+    """Minimal ADK trace calling the given tools."""
+    invoke = Span(
+        trace_id=trace_id,
+        span_id="invoke1",
+        parent_span_id=None,
+        operation_name="invoke_agent test_agent",
+        start_time=1000,
+        duration=10000,
+        tags={"otel.scope.name": "gcp.vertex.agent"},
+    )
+    llm = Span(
+        trace_id=trace_id,
+        span_id="llm1",
+        parent_span_id="invoke1",
+        operation_name="call_llm",
+        start_time=2000,
+        duration=1000,
+        tags={
+            "otel.scope.name": "gcp.vertex.agent",
+            "gcp.vertex.agent.llm_request": json.dumps(
+                {"contents": [{"role": "user", "parts": [{"text": "do something"}]}]}
+            ),
+        },
+    )
+    tool_spans = [
+        Span(
+            trace_id=trace_id,
+            span_id=f"tool{i}",
+            parent_span_id="invoke1",
+            operation_name=f"execute_tool {name}",
+            start_time=3000 + i * 100,
+            duration=100,
+            tags={"otel.scope.name": "gcp.vertex.agent"},
+        )
+        for i, name in enumerate(tools)
+    ]
+    llm_resp = Span(
+        trace_id=trace_id,
+        span_id="llm2",
+        parent_span_id="invoke1",
+        operation_name="call_llm",
+        start_time=5000,
+        duration=1000,
+        tags={
+            "otel.scope.name": "gcp.vertex.agent",
+            "gcp.vertex.agent.llm_response": json.dumps({"content": {"role": "model", "parts": [{"text": "done"}]}}),
+        },
+    )
+    invoke.children = [llm, *tool_spans, llm_resp]
+    return Trace(
+        trace_id=trace_id,
+        root_spans=[invoke],
+        all_spans=[invoke, llm, *tool_spans, llm_resp],
+    )
+
+
+# ── Unit tests: _skills_score ────────────────────────────────────────────────
+
+
+class TestSkillsScore:
+    def test_all_present_any_order(self):
+        assert _skills_score(["a", "b"], ["b", "a"], order_matters=False) == 1.0
+
+    def test_partial_match(self):
+        assert _skills_score(["a", "b", "c"], ["a", "c"], order_matters=False) == pytest.approx(2 / 3)
+
+    def test_none_present(self):
+        assert _skills_score(["x", "y"], ["a", "b"], order_matters=False) == 0.0
+
+    def test_empty_required(self):
+        assert _skills_score([], ["a", "b"], order_matters=False) == 1.0
+
+    def test_in_order_pass(self):
+        assert _skills_score(["a", "b"], ["a", "x", "b"], order_matters=True) == 1.0
+
+    def test_in_order_fail_wrong_order(self):
+        assert _skills_score(["a", "b"], ["b", "a"], order_matters=True) == pytest.approx(0.5)
+
+    def test_in_order_partial(self):
+        # required ["a","b","c"], called ["a","c"]
+        # a found at pos 0, b not found, c not found after b's position → 1/3
+        assert _skills_score(["a", "b", "c"], ["a", "c"], order_matters=True) == pytest.approx(1 / 3)
+
+    def test_extra_calls_ignored(self):
+        assert _skills_score(["a"], ["x", "a", "y"], order_matters=False) == 1.0
+
+
+# ── Unit tests: _evaluate_skills_trajectory ──────────────────────────────────
+
+
+class TestEvaluateSkillsTrajectory:
+    def _invocations(self, tools: list[str]):
+        trace = _make_trace(tools)
+        return convert_traces([trace])[0].invocations
+
+    def test_all_skills_found_passes(self):
+        invs = self._invocations(["search", "summarize"])
+        result = _evaluate_skills_trajectory(invs, ["search", "summarize"], None, 0.5)
+        assert result.score == 1.0
+        assert result.eval_status == "PASSED"
+
+    def test_no_skills_found_fails(self):
+        invs = self._invocations(["other_tool"])
+        result = _evaluate_skills_trajectory(invs, ["search"], None, 0.5)
+        assert result.score == 0.0
+        assert result.eval_status == "FAILED"
+
+    def test_partial_score(self):
+        invs = self._invocations(["search"])
+        result = _evaluate_skills_trajectory(invs, ["search", "summarize"], None, 0.6)
+        assert result.score == pytest.approx(0.5)
+        assert result.eval_status == "FAILED"
+
+    def test_in_order_pass(self):
+        invs = self._invocations(["fetch", "parse"])
+        result = _evaluate_skills_trajectory(invs, ["fetch", "parse"], "IN_ORDER", 0.5)
+        assert result.score == 1.0
+        assert result.eval_status == "PASSED"
+
+    def test_in_order_fail(self):
+        invs = self._invocations(["parse", "fetch"])
+        result = _evaluate_skills_trajectory(invs, ["fetch", "parse"], "IN_ORDER", 0.8)
+        assert result.score == pytest.approx(0.5)
+        assert result.eval_status == "FAILED"
+
+    def test_empty_skills_returns_error(self):
+        invs = self._invocations(["tool"])
+        result = _evaluate_skills_trajectory(invs, [], None, 0.5)
+        assert result.error is not None
+        assert result.score is None
+
+    def test_details_populated(self):
+        invs = self._invocations(["a", "b"])
+        result = _evaluate_skills_trajectory(invs, ["a"], None, 0.5)
+        assert result.details is not None
+        assert "comparisons" in result.details
+        comp = result.details["comparisons"][0]
+        assert comp["required_skills"] == ["a"]
+        assert "a" in comp["called_tools"]
+
+    def test_threshold_respected(self):
+        invs = self._invocations(["a", "b"])
+        result = _evaluate_skills_trajectory(invs, ["a", "b", "c"], None, threshold=0.9)
+        assert result.score == pytest.approx(2 / 3)
+        assert result.eval_status == "FAILED"
+
+
+# ── Integration tests: evaluate_builtin_metric ───────────────────────────────
+
+
+class TestEvaluateBuiltinMetricSkills:
+    def _invocations(self, tools: list[str]):
+        return convert_traces([_make_trace(tools)])[0].invocations
+
+    def test_dispatches_to_skills_evaluator(self):
+        invs = self._invocations(["geocode", "weather"])
+        result = asyncio.run(
+            evaluate_builtin_metric(
+                metric_name=METRICS_SKILLS_TRAJECTORY,
+                actual_invocations=invs,
+                expected_invocations=None,
+                judge_model=None,
+                threshold=0.5,
+                skills=["geocode", "weather"],
+            )
+        )
+        assert result.score == 1.0
+        assert result.eval_status == "PASSED"
+        assert result.metric_name == METRICS_SKILLS_TRAJECTORY
+
+    def test_missing_skills_returns_error(self):
+        invs = self._invocations(["geocode"])
+        result = asyncio.run(
+            evaluate_builtin_metric(
+                metric_name=METRICS_SKILLS_TRAJECTORY,
+                actual_invocations=invs,
+                expected_invocations=None,
+                judge_model=None,
+                threshold=0.5,
+                skills=[],
+            )
+        )
+        assert result.error is not None
+
+
+# ── Integration tests: run_evaluation ────────────────────────────────────────
+
+
+class TestRunEvaluationSkills:
+    def test_run_evaluation_skills_pass(self, tmp_path):
+        trace_file = tmp_path / "trace.json"
+        trace = _make_trace(["skill_a", "skill_b"])
+        import json as _json
+
+        from agentevals.loader.jaeger import JaegerJsonLoader
+
+        # Serialize via JaegerJsonLoader round-trip isn't available; use converter + write raw
+        # Instead write a minimal jaeger trace file
+        jaeger = {
+            "data": [
+                {
+                    "traceID": "t1",
+                    "spans": [
+                        {
+                            "traceID": "t1",
+                            "spanID": "invoke1",
+                            "operationName": "invoke_agent test_agent",
+                            "references": [],
+                            "startTime": 1000000,
+                            "duration": 10000000,
+                            "tags": [{"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"}],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                        {
+                            "traceID": "t1",
+                            "spanID": "llm1",
+                            "operationName": "call_llm",
+                            "references": [{"refType": "CHILD_OF", "traceID": "t1", "spanID": "invoke1"}],
+                            "startTime": 2000000,
+                            "duration": 1000000,
+                            "tags": [
+                                {"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"},
+                                {
+                                    "key": "gcp.vertex.agent.llm_request",
+                                    "type": "string",
+                                    "value": _json.dumps(
+                                        {"contents": [{"role": "user", "parts": [{"text": "do something"}]}]}
+                                    ),
+                                },
+                            ],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                        {
+                            "traceID": "t1",
+                            "spanID": "tool0",
+                            "operationName": "execute_tool skill_a",
+                            "references": [{"refType": "CHILD_OF", "traceID": "t1", "spanID": "invoke1"}],
+                            "startTime": 3000000,
+                            "duration": 100000,
+                            "tags": [{"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"}],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                        {
+                            "traceID": "t1",
+                            "spanID": "tool1",
+                            "operationName": "execute_tool skill_b",
+                            "references": [{"refType": "CHILD_OF", "traceID": "t1", "spanID": "invoke1"}],
+                            "startTime": 3100000,
+                            "duration": 100000,
+                            "tags": [{"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"}],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                        {
+                            "traceID": "t1",
+                            "spanID": "llm2",
+                            "operationName": "call_llm",
+                            "references": [{"refType": "CHILD_OF", "traceID": "t1", "spanID": "invoke1"}],
+                            "startTime": 5000000,
+                            "duration": 1000000,
+                            "tags": [
+                                {"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"},
+                                {
+                                    "key": "gcp.vertex.agent.llm_response",
+                                    "type": "string",
+                                    "value": _json.dumps({"content": {"role": "model", "parts": [{"text": "done"}]}}),
+                                },
+                            ],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                    ],
+                    "processes": {"p1": {"serviceName": "test_agent", "tags": []}},
+                }
+            ]
+        }
+        trace_file.write_text(_json.dumps(jaeger))
+
+        config = EvalRunConfig(
+            trace_files=[str(trace_file)],
+            metrics=[METRICS_SKILLS_TRAJECTORY],
+            skills_trajectory_skills=["skill_a", "skill_b"],
+        )
+        result = asyncio.run(run_evaluation(config))
+
+        assert len(result.errors) == 0
+        mr = result.trace_results[0].metric_results[0]
+        assert mr.metric_name == METRICS_SKILLS_TRAJECTORY
+        assert mr.score == 1.0
+        assert mr.eval_status == "PASSED"
+        assert mr.duration_ms is not None
+
+    def test_run_evaluation_skills_in_order_fail(self, tmp_path):
+        import json as _json
+
+        jaeger = {
+            "data": [
+                {
+                    "traceID": "t2",
+                    "spans": [
+                        {
+                            "traceID": "t2",
+                            "spanID": "invoke1",
+                            "operationName": "invoke_agent test_agent",
+                            "references": [],
+                            "startTime": 1000000,
+                            "duration": 10000000,
+                            "tags": [{"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"}],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                        {
+                            "traceID": "t2",
+                            "spanID": "llm1",
+                            "operationName": "call_llm",
+                            "references": [{"refType": "CHILD_OF", "traceID": "t2", "spanID": "invoke1"}],
+                            "startTime": 2000000,
+                            "duration": 1000000,
+                            "tags": [
+                                {"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"},
+                                {
+                                    "key": "gcp.vertex.agent.llm_request",
+                                    "type": "string",
+                                    "value": _json.dumps({"contents": [{"role": "user", "parts": [{"text": "go"}]}]}),
+                                },
+                            ],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                        # skill_b called BEFORE skill_a — wrong order
+                        {
+                            "traceID": "t2",
+                            "spanID": "tool0",
+                            "operationName": "execute_tool skill_b",
+                            "references": [{"refType": "CHILD_OF", "traceID": "t2", "spanID": "invoke1"}],
+                            "startTime": 3000000,
+                            "duration": 100000,
+                            "tags": [{"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"}],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                        {
+                            "traceID": "t2",
+                            "spanID": "tool1",
+                            "operationName": "execute_tool skill_a",
+                            "references": [{"refType": "CHILD_OF", "traceID": "t2", "spanID": "invoke1"}],
+                            "startTime": 3100000,
+                            "duration": 100000,
+                            "tags": [{"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"}],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                        {
+                            "traceID": "t2",
+                            "spanID": "llm2",
+                            "operationName": "call_llm",
+                            "references": [{"refType": "CHILD_OF", "traceID": "t2", "spanID": "invoke1"}],
+                            "startTime": 5000000,
+                            "duration": 1000000,
+                            "tags": [
+                                {"key": "otel.scope.name", "type": "string", "value": "gcp.vertex.agent"},
+                                {
+                                    "key": "gcp.vertex.agent.llm_response",
+                                    "type": "string",
+                                    "value": _json.dumps({"content": {"role": "model", "parts": [{"text": "done"}]}}),
+                                },
+                            ],
+                            "logs": [],
+                            "processID": "p1",
+                        },
+                    ],
+                    "processes": {"p1": {"serviceName": "test_agent", "tags": []}},
+                }
+            ]
+        }
+        trace_file = tmp_path / "trace2.json"
+        trace_file.write_text(_json.dumps(jaeger))
+
+        config = EvalRunConfig(
+            trace_files=[str(trace_file)],
+            metrics=[METRICS_SKILLS_TRAJECTORY],
+            skills_trajectory_skills=["skill_a", "skill_b"],
+            skills_trajectory_match_type="IN_ORDER",
+            threshold=0.8,
+        )
+        result = asyncio.run(run_evaluation(config))
+        mr = result.trace_results[0].metric_results[0]
+        assert mr.score < 1.0
+        assert mr.eval_status == "FAILED"


### PR DESCRIPTION
Closes agentevals-dev/evaluators#10.

## Summary

- Adds `skills_trajectory_v1`, a deterministic no-LLM evaluator that checks whether specific skills (tool names) were called during agent invocations
- Supports `ANY_ORDER` (default) and `IN_ORDER` match types
- Score = fraction of required skills found, averaged across invocations
- Wired through `EvalRunConfig`, `runner.py`, and the `/metrics` API endpoint

## Design

The evaluator lives entirely in `builtin_metrics.py` as two small pure functions (`_skills_score`, `_evaluate_skills_trajectory`) that exit before the ADK registry path — no LLM, no external deps, no boilerplate.

Config keys added to `EvalRunConfig`:
- `skills_trajectory_skills: list[str]` — required skill names
- `skills_trajectory_match_type: str` — `ANY_ORDER` (default) or `IN_ORDER`

## Changes

- `builtin_metrics.py` — evaluator logic + `METRICS_SKILLS_TRAJECTORY` constant
- `config.py` — two new `EvalRunConfig` fields with validation
- `runner.py` — pass `skills` / `skills_match_type` through `_evaluate_trace`
- `api/routes.py` — expose metric in `/metrics` (manually appended, not in ADK registry)
- `tests/test_skills_evaluator.py` — 20 tests: unit, integration, end-to-end
- `tests/test_api.py` — update fallback metrics count

AI assistance: Claude Sonnet used to write and iterate on the implementation. I reviewed and understand every line.