### PR TITLE
fix(readme): use absolute URLs for logo images so they render on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo-color-on-transparent.svg">
-    <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-dark-on-transparent.svg">
-    <img src="docs/assets/logo-color-on-transparent.svg" alt="agentevals" width="420" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/agentevals-dev/agentevals/main/docs/assets/logo-color-on-transparent.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/agentevals-dev/agentevals/main/docs/assets/logo-dark-on-transparent.svg">
+    <img src="https://raw.githubusercontent.com/agentevals-dev/agentevals/main/docs/assets/logo-color-on-transparent.svg" alt="agentevals" width="420" />
   </picture>
 </p>
 


### PR DESCRIPTION
## Summary

- Fixes the broken logo image on the [PyPI project page](https://pypi.org/project/agentevals-cli/)
- Replaces relative paths (`docs/assets/logo-*.svg`) with absolute `raw.githubusercontent.com` URLs
- PyPI does not serve local files, so relative paths result in a broken image; absolute URLs work both on PyPI and GitHub

Closes #62

> Note: AI assisted with identifying the root cause and generating the fix. The change is a straightforward 3-line diff that I understand fully.