### PR TITLE
add AWS AgentCore zero code example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,7 @@ agentevals accepts OTLP/HTTP on port 4318 (`http/protobuf` and `http/json`) and 
 | [zero-code-examples/strands/](./zero-code-examples/strands/) | Strands | OpenAI |
 | [zero-code-examples/adk/](./zero-code-examples/adk/) | Google ADK | Gemini |
 | [zero-code-examples/pydantic-ai/](./zero-code-examples/pydantic-ai/) | Pydantic AI | OpenAI |
+| [zero-code-examples/agentcore/](./zero-code-examples/agentcore/) | AWS AgentCore | Amazon Bedrock |
 
 This approach works with any framework that has OTel instrumentation: LangChain, Strands, Google ADK, etc. If your framework already emits OTel spans, you only need to add `OTLPSpanExporter` (and `OTLPLogExporter` if it uses GenAI log-based content delivery).
 
@@ -105,6 +106,7 @@ Detection checks for `gen_ai.request.model` / `gen_ai.input.messages` (GenAI sem
 | [zero-code-examples/strands/](./zero-code-examples/strands/) | Strands | OpenAI | GenAI semconv (events*) | Standard OTLP export |
 | [zero-code-examples/adk/](./zero-code-examples/adk/) | Google ADK | Gemini | ADK built-in | Standard OTLP export |
 | [zero-code-examples/pydantic-ai/](./zero-code-examples/pydantic-ai/) | Pydantic AI | OpenAI | GenAI semconv (span attrs) | Standard OTLP export |
+| [zero-code-examples/agentcore/](./zero-code-examples/agentcore/) | AWS AgentCore | Amazon Bedrock | GenAI semconv (events*) | Standard OTLP export |
 | [langchain_agent](./langchain_agent/) | LangChain | OpenAI | GenAI semconv (logs) | SDK WebSocket |
 | [strands_agent](./strands_agent/) | Strands | OpenAI | GenAI semconv (events*) | SDK WebSocket |
 | [dice_agent](./dice_agent/) | Google ADK | Gemini | ADK built-in | SDK WebSocket |
@@ -227,6 +229,9 @@ python examples/zero-code-examples/strands/run.py
 python examples/zero-code-examples/adk/run.py
 python examples/zero-code-examples/pydantic-ai/run.py
 
+python examples/zero-code-examples/agentcore/run.py &
+curl http://localhost:8080/invocations -d '{"prompt": "Roll a 20-sided die for me"}'
+
 # SDK examples:
 python examples/sdk_example/context_manager_example.py
 python examples/sdk_example/decorator_example.py
@@ -241,7 +246,7 @@ python examples/strands_agent/main.py
 Traces stream to the dev server in real-time. Evaluation runs automatically when the session completes.
 
 See each example's README for prerequisites and detailed instructions:
-- [zero-code-examples/](./zero-code-examples/) (LangChain, Strands, ADK, OpenAI Agents, Pydantic AI — standard OTLP)
+- [zero-code-examples/](./zero-code-examples/) (LangChain, Strands, ADK, OpenAI Agents, Pydantic AI, AWS AgentCore, standard OTLP)
 - [dice_agent/README.md](./dice_agent/README.md) (Google ADK + Gemini)
 - [langchain_agent/README.md](./langchain_agent/README.md) (LangChain + OpenAI, SDK)
 - [strands_agent/](./strands_agent/) (Strands + OpenAI, SDK)

--- a/examples/zero-code-examples/agentcore/requirements.txt
+++ b/examples/zero-code-examples/agentcore/requirements.txt
@@ -1,0 +1,6 @@
+bedrock-agentcore>=1.8.0
+strands-agents>=1.35.0
+boto3>=1.38.0
+opentelemetry-sdk>=1.36.0
+opentelemetry-exporter-otlp-proto-http>=1.36.0
+python-dotenv>=1.0.0

--- a/examples/zero-code-examples/agentcore/run.py
+++ b/examples/zero-code-examples/agentcore/run.py
@@ -33,8 +33,9 @@ from strands.telemetry import StrandsTelemetry
 
 load_dotenv(override=True)
 os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental")
-os.environ.setdefault("OTEL_RESOURCE_ATTRIBUTES",
-    "agentevals.eval_set_id=agentcore_eval,agentevals.session_name=agentcore-zero-code")
+os.environ.setdefault(
+    "OTEL_RESOURCE_ATTRIBUTES", "agentevals.eval_set_id=agentcore_eval,agentevals.session_name=agentcore-zero-code"
+)
 
 _telemetry = StrandsTelemetry()
 _telemetry.tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(), schedule_delay_millis=1000))
@@ -60,7 +61,7 @@ async def handler(payload):
     agent = Agent(
         model=BedrockModel(model_id="us.amazon.nova-pro-v1:0"),
         tools=[roll_die, check_prime],
-        system_prompt="Use roll_die when asked to roll dice. Use check_prime when asked about prime numbers.",
+        system_prompt="You are a helpful assistant. You can roll dice and check if numbers are prime.",
     )
     async for event in agent.stream_async(prompt):
         yield event

--- a/examples/zero-code-examples/agentcore/run.py
+++ b/examples/zero-code-examples/agentcore/run.py
@@ -1,11 +1,19 @@
 """Run a Strands dice agent inside AWS AgentCore with standard OTLP export.
 
-Demonstrates zero-code integration: the BedrockAgentCoreApp runtime wraps a
-Strands agent and serves it over HTTP. StrandsTelemetry emits OTel spans which
-are forwarded to agentevals via OTLPSpanExporter, with no agentevals SDK needed.
+Demonstrates zero-code integration: no agentevals SDK is needed.
+StrandsTelemetry emits OTel spans which are forwarded to agentevals
+via a plain OTLPSpanExporter.
+
+The key difference from a plain Strands script is the AgentCore runtime:
+BedrockAgentCoreApp wraps the agent as an HTTP server. The handler is an
+async generator decorated with @app.entrypoint and the server starts with
+app.run(), listening for POST /invocations requests.
+
+Strands telemetry exports spans even when Bedrock raises NoCredentialsError,
+so the OTel pipeline can be tested locally without AWS credentials.
 
 The agent exposes two tools:
-  roll_die   -- rolls a die with a given number of sides
+  roll_die    -- rolls a die with a given number of sides
   check_prime -- checks whether a number is prime
 
 Prerequisites:

--- a/examples/zero-code-examples/agentcore/run.py
+++ b/examples/zero-code-examples/agentcore/run.py
@@ -1,0 +1,69 @@
+"""Run a Strands dice agent inside AWS AgentCore with standard OTLP export.
+
+Demonstrates zero-code integration: the BedrockAgentCoreApp runtime wraps a
+Strands agent and serves it over HTTP. StrandsTelemetry emits OTel spans which
+are forwarded to agentevals via OTLPSpanExporter, with no agentevals SDK needed.
+
+The agent exposes two tools:
+  roll_die   -- rolls a die with a given number of sides
+  check_prime -- checks whether a number is prime
+
+Prerequisites:
+    1. pip install -r examples/zero-code-examples/agentcore/requirements.txt
+    2. agentevals serve --dev
+    3. Configure AWS credentials (AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID, etc.)
+       or set AWS_DEFAULT_REGION=us-east-1 for local testing without Bedrock.
+
+Usage:
+    python examples/zero-code-examples/agentcore/run.py &
+    curl http://localhost:8080/invocations -H "Content-Type: application/json" \\
+         -d '{"prompt": "Roll a 20-sided die for me"}'
+"""
+
+import os
+import random
+
+from bedrock_agentcore import BedrockAgentCoreApp
+from dotenv import load_dotenv
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from strands import Agent, tool
+from strands.models import BedrockModel
+from strands.telemetry import StrandsTelemetry
+
+load_dotenv(override=True)
+os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental")
+os.environ.setdefault("OTEL_RESOURCE_ATTRIBUTES",
+    "agentevals.eval_set_id=agentcore_eval,agentevals.session_name=agentcore-zero-code")
+
+_telemetry = StrandsTelemetry()
+_telemetry.tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(), schedule_delay_millis=1000))
+
+app = BedrockAgentCoreApp()
+
+
+@tool
+def roll_die(sides: int = 6) -> int:
+    """Roll a die with the given number of sides."""
+    return random.randint(1, sides)
+
+
+@tool
+def check_prime(n: int) -> bool:
+    """Return True if number is prime."""
+    return n >= 2 and all(n % i for i in range(2, int(n**0.5) + 1))
+
+
+@app.entrypoint
+async def handler(payload):
+    prompt = payload.get("prompt", "Hello!")
+    agent = Agent(
+        model=BedrockModel(model_id="us.amazon.nova-pro-v1:0"),
+        tools=[roll_die, check_prime],
+        system_prompt="Use roll_die when asked to roll dice. Use check_prime when asked about prime numbers.",
+    )
+    async for event in agent.stream_async(prompt):
+        yield event
+
+
+app.run()

--- a/tests/integration/test_live_agents.py
+++ b/tests/integration/test_live_agents.py
@@ -15,10 +15,12 @@ Tests are synchronous because:
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import os
 import subprocess
 import sys
+import time
 
 import httpx
 import pytest
@@ -45,6 +47,7 @@ _skip_no_pydantic_ai = pytest.mark.skipif(
 )
 
 
+
 def _run_agent(
     script: str,
     otlp_http_port: int,
@@ -68,6 +71,41 @@ def _run_agent(
         timeout=timeout,
         cwd=REPO_ROOT,
     )
+
+
+_AGENTCORE_ENV = {"OTEL_SEMCONV_STABILITY_OPT_IN": "gen_ai_latest_experimental"}
+_AGENTCORE_SCRIPT = "examples/zero-code-examples/agentcore/run.py"
+_AGENTCORE_PORT = int(os.environ.get("AGENTCORE_PORT", "8080"))
+
+
+@contextlib.contextmanager
+def _agentcore_server(otlp_http_port: int, session_name: str, extra_env: dict | None = None):
+    env = {**os.environ,
+           "OTEL_EXPORTER_OTLP_ENDPOINT": f"http://127.0.0.1:{otlp_http_port}",
+           "OTEL_RESOURCE_ATTRIBUTES": f"agentevals.eval_set_id=e2e-test,agentevals.session_name={session_name}",
+           **(extra_env or {})}
+    proc = subprocess.Popen([sys.executable, os.path.join(REPO_ROOT, _AGENTCORE_SCRIPT)], env=env, cwd=REPO_ROOT)
+    try:
+        for _ in range(20):
+            if proc.poll() is not None:
+                raise RuntimeError(f"agentcore server exited early (code {proc.returncode})")
+            try:
+                httpx.get(f"http://127.0.0.1:{_AGENTCORE_PORT}/ping", timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            proc.kill()
+            raise RuntimeError("agentcore server did not start within 10s")
+        yield proc
+    finally:
+        time.sleep(2)
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
 
 @_skip_no_openai
@@ -370,6 +408,37 @@ class TestPydanticAIZeroCode:
         assert resp.status_code == 200
         session_ids = [s["sessionId"] for s in resp.json()["data"]]
         assert session_name in session_ids
+
+
+class TestAgentCoreZeroCode:
+    def test_session_created_spans_only(self, live_servers):
+        main_port, otlp_http_port, mgr = live_servers
+        session_name = "e2e-agentcore"
+        with _agentcore_server(otlp_http_port, session_name, extra_env=_AGENTCORE_ENV):
+            r = httpx.post(f"http://127.0.0.1:{_AGENTCORE_PORT}/invocations", json={"prompt": "Roll a 20-sided die"}, timeout=60)
+            assert r.status_code == 200
+        wait_for_session_complete_sync(mgr, session_name, timeout=60)
+        s = mgr.sessions[session_name]
+        assert s.is_complete and s.source == "otlp" and len(s.spans) > 0
+
+    def test_invocations_extracted(self, live_servers):
+        main_port, otlp_http_port, mgr = live_servers
+        session_name = "e2e-agentcore-inv"
+        with _agentcore_server(otlp_http_port, session_name, extra_env=_AGENTCORE_ENV):
+            r = httpx.post(f"http://127.0.0.1:{_AGENTCORE_PORT}/invocations", json={"prompt": "Is 17 prime?"}, timeout=60)
+            assert r.status_code == 200
+        wait_for_session_complete_sync(mgr, session_name, timeout=60)
+        assert len(mgr.sessions[session_name].invocations) > 0
+
+    def test_session_visible_via_api(self, live_servers):
+        main_port, otlp_http_port, mgr = live_servers
+        session_name = "e2e-agentcore-api"
+        with _agentcore_server(otlp_http_port, session_name, extra_env=_AGENTCORE_ENV):
+            r = httpx.post(f"http://127.0.0.1:{_AGENTCORE_PORT}/invocations", json={"prompt": "Hello!"}, timeout=60)
+            assert r.status_code == 200
+        wait_for_session_complete_sync(mgr, session_name, timeout=60)
+        data = httpx.get(f"http://127.0.0.1:{main_port}/api/streaming/sessions").json()["data"]
+        assert session_name in [s["sessionId"] for s in data]
 
 
 @_skip_no_openai

--- a/tests/integration/test_live_agents.py
+++ b/tests/integration/test_live_agents.py
@@ -47,7 +47,6 @@ _skip_no_pydantic_ai = pytest.mark.skipif(
 )
 
 
-
 def _run_agent(
     script: str,
     otlp_http_port: int,
@@ -80,10 +79,12 @@ _AGENTCORE_PORT = int(os.environ.get("AGENTCORE_PORT", "8080"))
 
 @contextlib.contextmanager
 def _agentcore_server(otlp_http_port: int, session_name: str, extra_env: dict | None = None):
-    env = {**os.environ,
-           "OTEL_EXPORTER_OTLP_ENDPOINT": f"http://127.0.0.1:{otlp_http_port}",
-           "OTEL_RESOURCE_ATTRIBUTES": f"agentevals.eval_set_id=e2e-test,agentevals.session_name={session_name}",
-           **(extra_env or {})}
+    env = {
+        **os.environ,
+        "OTEL_EXPORTER_OTLP_ENDPOINT": f"http://127.0.0.1:{otlp_http_port}",
+        "OTEL_RESOURCE_ATTRIBUTES": f"agentevals.eval_set_id=e2e-test,agentevals.session_name={session_name}",
+        **(extra_env or {}),
+    }
     proc = subprocess.Popen([sys.executable, os.path.join(REPO_ROOT, _AGENTCORE_SCRIPT)], env=env, cwd=REPO_ROOT)
     try:
         for _ in range(20):
@@ -415,7 +416,9 @@ class TestAgentCoreZeroCode:
         main_port, otlp_http_port, mgr = live_servers
         session_name = "e2e-agentcore"
         with _agentcore_server(otlp_http_port, session_name, extra_env=_AGENTCORE_ENV):
-            r = httpx.post(f"http://127.0.0.1:{_AGENTCORE_PORT}/invocations", json={"prompt": "Roll a 20-sided die"}, timeout=60)
+            r = httpx.post(
+                f"http://127.0.0.1:{_AGENTCORE_PORT}/invocations", json={"prompt": "Roll a 20-sided die"}, timeout=60
+            )
             assert r.status_code == 200
         wait_for_session_complete_sync(mgr, session_name, timeout=60)
         s = mgr.sessions[session_name]
@@ -425,7 +428,9 @@ class TestAgentCoreZeroCode:
         main_port, otlp_http_port, mgr = live_servers
         session_name = "e2e-agentcore-inv"
         with _agentcore_server(otlp_http_port, session_name, extra_env=_AGENTCORE_ENV):
-            r = httpx.post(f"http://127.0.0.1:{_AGENTCORE_PORT}/invocations", json={"prompt": "Is 17 prime?"}, timeout=60)
+            r = httpx.post(
+                f"http://127.0.0.1:{_AGENTCORE_PORT}/invocations", json={"prompt": "Is 17 prime?"}, timeout=60
+            )
             assert r.status_code == 200
         wait_for_session_complete_sync(mgr, session_name, timeout=60)
         assert len(mgr.sessions[session_name].invocations) > 0


### PR DESCRIPTION
Closes #93

Adds an AWS AgentCore zero-code OTLP example.

Uses BedrockAgentCoreApp from bedrock-agentcore and StrandsTelemetry for OTLP export.

    pip install -r examples/zero-code-examples/agentcore/requirements.txt
    export AWS_DEFAULT_REGION=us-east-1
    agentevals serve --dev
    python examples/zero-code-examples/agentcore/run.py
    curl http://localhost:8080/invocations -d '{"prompt": "Roll a 20-sided die"}'