### PR TITLE
BREAKING: consolidate 'metrics' and 'custom_evaluators' into `evaluators`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,7 +50,7 @@ Once running, submit a run with:
 ```bash
 curl -X POST http://localhost:8001/api/runs \
     -H 'content-type: application/json' \
-    -d '{"spec": {"approach": "trace_replay", "target": {"kind": "inline", "inline": {...}}, "evalConfig": {"metrics": ["tool_trajectory_avg_score"]}}}'
+    -d '{"spec": {"approach": "trace_replay", "target": {"kind": "inline", "inline": {...}}, "evalConfig": {"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]}}}'
 ```
 
 Then poll `GET /api/runs/{runId}` and `GET /api/runs/{runId}/results`. Without `storage.backend=postgres`, the `/api/runs` endpoints return 503 with a hint pointing at the env var.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ See the [Custom Evaluators guide](docs/custom-evaluators.md) for the full protoc
 agentevals serve            # bundled UI on http://localhost:8001
 ```
 
-Upload traces and eval sets, select metrics, and view results with interactive span trees. Live-streamed traces appear in the "Local Dev" tab, grouped by session ID. For running from source, see [DEVELOPMENT.md](DEVELOPMENT.md).
+Upload traces and eval sets, select evaluators, and view results with interactive span trees. Live-streamed traces appear in the "Local Dev" tab, grouped by session ID. For running from source, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 Interactive API docs are available at `/docs` (Swagger) and `/redoc` while the server is running. The OTLP receiver on port 4318 serves its own docs at `http://localhost:4318/docs`.
 

--- a/docs/eval-set-format.md
+++ b/docs/eval-set-format.md
@@ -1,6 +1,6 @@
 # Eval Set Format
 
-An eval set is a JSON file containing golden reference data that metrics compare agent traces against. It follows the [Google ADK `EvalSet`](https://github.com/google/adk-python/blob/main/src/google/adk/evaluation/eval_set.py) schema, which means eval sets are portable between agentevals and ADK tooling.
+An eval set is a JSON file containing golden reference data that evaluators compare agent traces against. It follows the [Google ADK `EvalSet`](https://github.com/google/adk-python/blob/main/src/google/adk/evaluation/eval_set.py) schema, which means eval sets are portable between agentevals and ADK tooling.
 
 Most users will not need to author eval sets by hand. The web UI can generate them from live sessions (mark a session as golden, and the server builds the eval set automatically). This document is for users who want to create or edit eval sets directly, whether for CLI usage, CI pipelines, or version-controlled test suites.
 
@@ -203,9 +203,9 @@ The `parts` array can contain text, function calls, or function responses. Most 
 
 Each `FunctionCall` has `name`, `args`, and `id`. Each `FunctionResponse` has `name`, `response`, and `id`. Match `id` values between calls and responses to pair them.
 
-## Which Metrics Use Eval Sets
+## Which Evaluators Use Eval Sets
 
-Not all metrics require an eval set. Use `agentevals list-metrics` to see which do:
+Not all evaluators require an eval set. Use `agentevals evaluator list --source builtin` to see which built-in evaluators do:
 
 | Metric | Needs Eval Set | What It Reads |
 |---|---|---|

--- a/examples/dice_agent/README.md
+++ b/examples/dice_agent/README.md
@@ -149,7 +149,7 @@ Update `main.py` to test the new functionality.
 **After agent completes:**
 - Status changes to "EVALUATED"
 - Evaluation results appear as colored badges
-- Each metric shows: name and score (e.g., "tool_trajectory_avg_score: 1.00")
+- Each evaluator result shows: name and score (e.g., "tool_trajectory_avg_score: 1.00")
 
 **Multiple runs:**
 - Each run creates a new session with model name in ID

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -221,7 +221,7 @@ This captures the GPT-5 session's tool trajectory and final responses as the gol
 2. Select both sessions (the `gpt-4.1-mini` session and the `gpt-5` session)
 3. Click **Evaluate**
 4. Select the `helm-agent-comparison` eval set
-5. Choose the metrics:
+5. Choose the evaluators:
    - **tool_trajectory_avg_score**: Did the agent call the correct tools in the correct order?
    - **response_match_score**: Did the agent produce responses consistent with the golden reference?
 6. Run the evaluation
@@ -241,7 +241,7 @@ Compare the two sessions in the results table:
 
 <img width="1914" height="1154" alt="image" src="https://github.com/user-attachments/assets/5939a8d4-3775-4cf1-9cf2-d3b6b4afd582" />
 
-You can also click an individual conversation and see a breakdown of each evaluators.
+You can also click an individual conversation and see a breakdown of each evaluator.
 
 <img width="1916" height="1348" alt="image" src="https://github.com/user-attachments/assets/984b3d29-8018-4fcb-9036-bb7c6e97d9ff" />
 

--- a/src/agentevals/api/routes.py
+++ b/src/agentevals/api/routes.py
@@ -18,14 +18,7 @@ from pydantic.alias_generators import to_camel
 from agentevals import __version__
 
 from ..builtin_metrics import METRICS_NEEDING_EXPECTED, METRICS_NEEDING_GCP, METRICS_NEEDING_LLM
-from ..config import (
-    BuiltinMetricDef,
-    CodeEvaluatorDef,
-    CustomEvaluatorDef,
-    EvalParams,
-    EvalRunConfig,
-    OpenAIEvalDef,
-)
+from ..config import EvalParams, EvalRunConfig
 from ..converter import convert_traces
 from ..extraction import get_extractor
 from ..loader import load_traces
@@ -120,25 +113,6 @@ async def _maybe_persist_evaluate_run(
 router = APIRouter()
 
 _MAX_JSON_BODY_BYTES = 50 * 1024 * 1024  # 50 MB (multipart endpoints allow 10 MB per file)
-
-_TYPE_TO_MODEL = {
-    "builtin": BuiltinMetricDef,
-    "code": CodeEvaluatorDef,
-    "openai_eval": OpenAIEvalDef,
-}
-
-
-def _parse_custom_evaluators(raw: list[dict]) -> list[CustomEvaluatorDef]:
-    """Parse a list of custom evaluator dicts from the API config JSON."""
-    defs: list[CustomEvaluatorDef] = []
-    for entry in raw:
-        evaluator_type = entry.get("type", "builtin")
-        model_cls = _TYPE_TO_MODEL.get(evaluator_type)
-        if not model_cls:
-            raise ValueError(f"Unknown custom evaluator type: {evaluator_type}")
-        defs.append(model_cls.model_validate(entry))
-    return defs
-
 
 @router.get("/health", response_model=StandardResponse[HealthData])
 async def health_check():
@@ -489,10 +463,10 @@ async def evaluate_traces(
     eval_set_file: UploadFile | None = File(None),
 ):
     """
-    Evaluate agent traces using specified metrics.
+    Evaluate agent traces using the provided evaluator configuration.
 
     Args:
-        trace_files: List of Jaeger JSON trace files
+        trace_files: List of Jaeger or OTLP JSON trace files
         config: JSON string with evaluation configuration
         eval_set_file: Optional golden eval set file
 
@@ -556,40 +530,23 @@ async def evaluate_traces(
                     )
                 f.write(content)
 
-        metrics = config_dict.get("metrics", ["tool_trajectory_avg_score"])
-        if not metrics or not isinstance(metrics, list):
-            raise HTTPException(
-                status_code=400,
-                detail="Config must include 'metrics' as a non-empty array",
+        try:
+            eval_config = EvalRunConfig.model_validate(
+                {
+                    **config_dict,
+                    "traceFiles": trace_paths,
+                    "evalSetFile": eval_set_path,
+                    "traceFormat": trace_format,
+                }
             )
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid config: {exc}") from exc
 
-        threshold = config_dict.get("threshold")
-        if threshold is not None and (threshold < 0 or threshold > 1):
-            raise HTTPException(
-                status_code=400,
-                detail="Threshold must be between 0 and 1",
-            )
-
-        custom_evaluators: list[CustomEvaluatorDef] = []
-        raw_custom = config_dict.get("customEvaluators", config_dict.get("customMetrics", []))
-        if raw_custom:
-            try:
-                custom_evaluators = _parse_custom_evaluators(raw_custom)
-            except Exception as exc:
-                raise HTTPException(status_code=400, detail=f"Invalid customEvaluators: {exc}") from exc
-
-        eval_config = EvalRunConfig(
-            trace_files=trace_paths,
-            eval_set_file=eval_set_path,
-            metrics=metrics,
-            custom_evaluators=custom_evaluators,
-            trace_format=trace_format,
-            judge_model=config_dict.get("judgeModel"),
-            threshold=threshold,
-            trajectory_match_type=config_dict.get("trajectoryMatchType"),
+        logger.info(
+            "Evaluating %d trace file(s) with evaluators: %s",
+            len(trace_paths),
+            [e.name for e in eval_config.evaluators],
         )
-
-        logger.info(f"Evaluating {len(trace_paths)} trace file(s) with metrics: {metrics}")
         result = await run_evaluation(eval_config)
 
         run_id = await _maybe_persist_evaluate_run(
@@ -675,35 +632,18 @@ async def evaluate_traces_stream(
                         return
                     f.write(content)
 
-            metrics = config_dict.get("metrics", ["tool_trajectory_avg_score"])
-            if not metrics or not isinstance(metrics, list):
-                yield f"data: {SSEErrorEvent(error='Config must include metrics as a non-empty array').model_dump_json(by_alias=True)}\n\n"
+            try:
+                eval_config = EvalRunConfig.model_validate(
+                    {
+                        **config_dict,
+                        "traceFiles": trace_paths,
+                        "evalSetFile": eval_set_path,
+                        "traceFormat": trace_format,
+                    }
+                )
+            except Exception as exc:
+                yield f"data: {SSEErrorEvent(error=f'Invalid config: {exc}').model_dump_json(by_alias=True)}\n\n"
                 return
-
-            threshold = config_dict.get("threshold")
-            if threshold is not None and (threshold < 0 or threshold > 1):
-                yield f"data: {SSEErrorEvent(error='Threshold must be between 0 and 1').model_dump_json(by_alias=True)}\n\n"
-                return
-
-            custom_evaluators: list[CustomEvaluatorDef] = []
-            raw_custom = config_dict.get("customEvaluators", config_dict.get("customMetrics", []))
-            if raw_custom:
-                try:
-                    custom_evaluators = _parse_custom_evaluators(raw_custom)
-                except Exception as exc:
-                    yield f"data: {SSEErrorEvent(error=f'Invalid customEvaluators: {exc}').model_dump_json(by_alias=True)}\n\n"
-                    return
-
-            eval_config = EvalRunConfig(
-                trace_files=trace_paths,
-                eval_set_file=eval_set_path,
-                metrics=metrics,
-                custom_evaluators=custom_evaluators,
-                trace_format=trace_format,
-                judge_model=config_dict.get("judgeModel"),
-                threshold=threshold,
-                trajectory_match_type=config_dict.get("trajectoryMatchType"),
-            )
 
             for trace_file_path in trace_paths:
                 try:

--- a/src/agentevals/api/routes.py
+++ b/src/agentevals/api/routes.py
@@ -114,6 +114,7 @@ router = APIRouter()
 
 _MAX_JSON_BODY_BYTES = 50 * 1024 * 1024  # 50 MB (multipart endpoints allow 10 MB per file)
 
+
 @router.get("/health", response_model=StandardResponse[HealthData])
 async def health_check():
     return StandardResponse(data=HealthData(status="ok", version=__version__))

--- a/src/agentevals/api/runs_routes.py
+++ b/src/agentevals/api/runs_routes.py
@@ -76,6 +76,8 @@ async def submit_run(payload: RunRequest, request: Request):
     service = _service(request)
     try:
         run = await service.submit(run_id=payload.run_id, spec=payload.spec)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
     except RunSubmitConflict as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/src/agentevals/api/streaming_routes.py
+++ b/src/agentevals/api/streaming_routes.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..config import BuiltinMetricDef, EvalRunConfig, EvaluatorDef
 from ..converter import convert_traces
@@ -42,6 +42,8 @@ class CreateEvalSetRequest(BaseModel):
 
 
 class EvaluateSessionsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     golden_session_id: str
     eval_set_id: str
     evaluators: list[EvaluatorDef] = Field(default_factory=lambda: [BuiltinMetricDef(name="tool_trajectory_avg_score")])

--- a/src/agentevals/api/streaming_routes.py
+++ b/src/agentevals/api/streaming_routes.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-from ..config import EvalRunConfig
+from ..config import BuiltinMetricDef, EvalRunConfig, EvaluatorDef
 from ..converter import convert_traces
 from ..loader.otlp import OtlpJsonLoader
 from ..runner import run_evaluation
@@ -44,9 +44,7 @@ class CreateEvalSetRequest(BaseModel):
 class EvaluateSessionsRequest(BaseModel):
     golden_session_id: str
     eval_set_id: str
-    metrics: list[str] = ["tool_trajectory_avg_score"]
-    judge_model: str = "gemini-2.5-flash"
-    trajectory_match_type: Literal["EXACT", "IN_ORDER", "ANY_ORDER"] | None = None
+    evaluators: list[EvaluatorDef] = Field(default_factory=lambda: [BuiltinMetricDef(name="tool_trajectory_avg_score")])
 
 
 class PrepareEvaluationRequest(BaseModel):
@@ -209,9 +207,7 @@ async def evaluate_sessions(
                         trace_files=[str(trace_file)],
                         trace_format="otlp-json",
                         eval_set_file=eval_set_file.name,
-                        metrics=request.metrics,
-                        judge_model=request.judge_model,
-                        trajectory_match_type=request.trajectory_match_type,
+                        evaluators=request.evaluators,
                     )
 
                     eval_result = await run_evaluation(config)

--- a/src/agentevals/cli.py
+++ b/src/agentevals/cli.py
@@ -52,23 +52,6 @@ def _relative_time(iso_str: str | None) -> str:
         return ""
 
 
-def _apply_builtin_overrides(evaluators, *, judge_model, threshold, trajectory_match_type):
-    updated = []
-    for evaluator in evaluators:
-        if getattr(evaluator, "type", None) == "builtin":
-            payload = evaluator.model_dump(by_alias=False)
-            if judge_model is not None:
-                payload["judge_model"] = judge_model
-            if threshold is not None:
-                payload["threshold"] = threshold
-            if trajectory_match_type is not None:
-                payload["trajectory_match_type"] = trajectory_match_type
-            updated.append(type(evaluator).model_validate(payload))
-        else:
-            updated.append(evaluator)
-    return updated
-
-
 @click.group()
 @click.version_option(version=__version__, prog_name="agentevals")
 @click.option(
@@ -160,60 +143,53 @@ def run(
     config_file: str | None,
 ) -> None:
     """Evaluate trace file(s) against the configured evaluators."""
-    from .config import EvalRunConfig, make_builtin_evaluator_entries
+    from .config import EvalRunConfig, apply_builtin_overrides, make_builtin_evaluator_entries
     from .output import format_results
     from .runner import run_evaluation
 
     explicit_metrics = list(metric) if metric else []
 
     if config_file:
-        from .eval_config_loader import load_eval_config, merge_configs
+        from .eval_config_loader import load_eval_config
 
-        file_config = load_eval_config(config_file)
-        config = file_config
+        config = load_eval_config(config_file)
         if explicit_metrics:
-            cli_config = EvalRunConfig(
-                trace_files=[],
-                evaluators=make_builtin_evaluator_entries(
-                    explicit_metrics,
-                    judge_model=judge_model,
-                    threshold=threshold,
-                    trajectory_match_type=trajectory_match_type,
-                ),
+            cli_evaluators = make_builtin_evaluator_entries(
+                explicit_metrics,
+                judge_model=judge_model,
+                threshold=threshold,
+                trajectory_match_type=trajectory_match_type,
             )
-            config = merge_configs(file_config, cli_config)
+            by_name = {e.name: e for e in config.evaluators}
+            for ev in cli_evaluators:
+                by_name[ev.name] = ev
+            config.evaluators = list(by_name.values())
         elif judge_model is not None or threshold is not None or trajectory_match_type is not None:
-            config = config.model_copy(
-                update={
-                    "evaluators": _apply_builtin_overrides(
-                        config.evaluators,
-                        judge_model=judge_model,
-                        threshold=threshold,
-                        trajectory_match_type=trajectory_match_type,
-                    )
-                }
+            config.evaluators = apply_builtin_overrides(
+                config.evaluators,
+                judge_model=judge_model,
+                threshold=threshold,
+                trajectory_match_type=trajectory_match_type,
             )
-        if trace_files:
-            config.trace_files = list(trace_files)
-        if eval_set is not None:
-            config.eval_set_file = eval_set
-        if trace_format is not None:
-            config.trace_format = trace_format
-        if output != "table":
-            config.output_format = output
     else:
         config = EvalRunConfig(
-            trace_files=list(trace_files),
-            eval_set_file=eval_set,
+            trace_files=[],
             evaluators=make_builtin_evaluator_entries(
-                explicit_metrics if explicit_metrics else None,
+                explicit_metrics or None,
                 judge_model=judge_model,
                 threshold=threshold,
                 trajectory_match_type=trajectory_match_type,
             ),
-            trace_format=trace_format,
-            output_format=output,
         )
+
+    if trace_files:
+        config.trace_files = list(trace_files)
+    if eval_set is not None:
+        config.eval_set_file = eval_set
+    if trace_format is not None:
+        config.trace_format = trace_format
+    if output != "table":
+        config.output_format = output
 
     result = asyncio.run(run_evaluation(config))
     formatted = format_results(result, fmt=config.output_format)

--- a/src/agentevals/cli.py
+++ b/src/agentevals/cli.py
@@ -5,7 +5,7 @@ Usage::
     agentevals run samples/helm.json --eval-set samples/eval_set_helm.json
     agentevals run samples/helm.json -m tool_trajectory_avg_score -m response_match_score
     agentevals run samples/helm.json --eval-set samples/eval_set_helm.json --output json
-    agentevals list-metrics
+    agentevals evaluator list --source builtin
 """
 
 from __future__ import annotations
@@ -50,6 +50,23 @@ def _relative_time(iso_str: str | None) -> str:
         return f"{years}y ago"
     except (ValueError, TypeError):
         return ""
+
+
+def _apply_builtin_overrides(evaluators, *, judge_model, threshold, trajectory_match_type):
+    updated = []
+    for evaluator in evaluators:
+        if getattr(evaluator, "type", None) == "builtin":
+            payload = evaluator.model_dump(by_alias=False)
+            if judge_model is not None:
+                payload["judge_model"] = judge_model
+            if threshold is not None:
+                payload["threshold"] = threshold
+            if trajectory_match_type is not None:
+                payload["trajectory_match_type"] = trajectory_match_type
+            updated.append(type(evaluator).model_validate(payload))
+        else:
+            updated.append(evaluator)
+    return updated
 
 
 @click.group()
@@ -129,7 +146,7 @@ def main(verbose: int) -> None:
     "config_file",
     type=click.Path(exists=True),
     default=None,
-    help="Path to an eval config YAML file defining metrics (including custom).",
+    help="Path to an eval config YAML file defining evaluators.",
 )
 def run(
     trace_files: tuple[str, ...],
@@ -142,8 +159,8 @@ def run(
     output: str,
     config_file: str | None,
 ) -> None:
-    """Evaluate trace file(s) against specified metrics."""
-    from .config import EvalRunConfig
+    """Evaluate trace file(s) against the configured evaluators."""
+    from .config import EvalRunConfig, make_builtin_evaluator_entries
     from .output import format_results
     from .runner import run_evaluation
 
@@ -153,79 +170,56 @@ def run(
         from .eval_config_loader import load_eval_config, merge_configs
 
         file_config = load_eval_config(config_file)
-
-        cli_config = EvalRunConfig(
-            trace_files=list(trace_files),
-            eval_set_file=eval_set,
-            metrics=explicit_metrics,
-            trace_format=trace_format,
-            judge_model=judge_model,
-            threshold=threshold,
-            trajectory_match_type=trajectory_match_type,
-            output_format=output,
-        )
-        config = merge_configs(file_config, cli_config)
+        config = file_config
+        if explicit_metrics:
+            cli_config = EvalRunConfig(
+                trace_files=[],
+                evaluators=make_builtin_evaluator_entries(
+                    explicit_metrics,
+                    judge_model=judge_model,
+                    threshold=threshold,
+                    trajectory_match_type=trajectory_match_type,
+                ),
+            )
+            config = merge_configs(file_config, cli_config)
+        elif judge_model is not None or threshold is not None or trajectory_match_type is not None:
+            config = config.model_copy(update={
+                "evaluators": _apply_builtin_overrides(
+                    config.evaluators,
+                    judge_model=judge_model,
+                    threshold=threshold,
+                    trajectory_match_type=trajectory_match_type,
+                )
+            })
+        if trace_files:
+            config.trace_files = list(trace_files)
+        if eval_set is not None:
+            config.eval_set_file = eval_set
+        if trace_format is not None:
+            config.trace_format = trace_format
+        if output != "table":
+            config.output_format = output
     else:
-        effective_metrics = explicit_metrics or ["tool_trajectory_avg_score"]
         config = EvalRunConfig(
             trace_files=list(trace_files),
             eval_set_file=eval_set,
-            metrics=effective_metrics,
+            evaluators=make_builtin_evaluator_entries(
+                explicit_metrics if explicit_metrics else None,
+                judge_model=judge_model,
+                threshold=threshold,
+                trajectory_match_type=trajectory_match_type,
+            ),
             trace_format=trace_format,
-            judge_model=judge_model,
-            threshold=threshold,
-            trajectory_match_type=trajectory_match_type,
             output_format=output,
         )
 
     result = asyncio.run(run_evaluation(config))
-    formatted = format_results(result, fmt=output)
+    formatted = format_results(result, fmt=config.output_format)
     click.echo(formatted)
 
     has_failure = any(mr.eval_status == "FAILED" or mr.error for tr in result.trace_results for mr in tr.metric_results)
     if has_failure or result.errors:
         sys.exit(1)
-
-
-@main.command("list-metrics")
-def list_metrics() -> None:
-    """List all available evaluation metrics.
-
-    DEPRECATED: use ``agentevals evaluator list --source builtin`` instead.
-    """
-    click.echo(
-        "Note: list-metrics is deprecated. Use 'agentevals evaluator list --source builtin' instead.\n",
-        err=True,
-    )
-    try:
-        from google.adk.evaluation.metric_evaluator_registry import (
-            DEFAULT_METRIC_EVALUATOR_REGISTRY,
-        )
-
-        metrics = DEFAULT_METRIC_EVALUATOR_REGISTRY.get_registered_metrics()
-        click.echo("Available metrics:\n")
-        for m in metrics:
-            desc = m.description or "No description"
-            click.echo(f"  {m.metric_name}")
-            click.echo(f"    {desc}")
-            if m.metric_value_info and m.metric_value_info.interval:
-                iv = m.metric_value_info.interval
-                lo = f"{'(' if iv.open_at_min else '['}{iv.min_value}"
-                hi = f"{iv.max_value}{')' if iv.open_at_max else ']'}"
-                click.echo(f"    Value range: {lo}, {hi}")
-            click.echo()
-    except ImportError as exc:
-        click.echo(
-            f"Could not load full metric registry ({exc}).\n"
-            "Some eval dependencies may be missing. Install with:\n"
-            '  pip install "google-adk[eval]"\n'
-        )
-        click.echo("Known built-in metrics:\n")
-        from google.adk.evaluation.eval_metrics import PrebuiltMetrics
-
-        for pm in PrebuiltMetrics:
-            click.echo(f"  {pm.value}")
-        click.echo()
 
 
 # ---------------------------------------------------------------------------

--- a/src/agentevals/cli.py
+++ b/src/agentevals/cli.py
@@ -183,14 +183,16 @@ def run(
             )
             config = merge_configs(file_config, cli_config)
         elif judge_model is not None or threshold is not None or trajectory_match_type is not None:
-            config = config.model_copy(update={
-                "evaluators": _apply_builtin_overrides(
-                    config.evaluators,
-                    judge_model=judge_model,
-                    threshold=threshold,
-                    trajectory_match_type=trajectory_match_type,
-                )
-            })
+            config = config.model_copy(
+                update={
+                    "evaluators": _apply_builtin_overrides(
+                        config.evaluators,
+                        judge_model=judge_model,
+                        threshold=threshold,
+                        trajectory_match_type=trajectory_match_type,
+                    )
+                }
+            )
         if trace_files:
             config.trace_files = list(trace_files)
         if eval_set is not None:

--- a/src/agentevals/config.py
+++ b/src/agentevals/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
@@ -9,20 +10,35 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
 
 
+def _normalize_trajectory_match_type(v: str | None) -> str | None:
+    valid = {"EXACT", "IN_ORDER", "ANY_ORDER"}
+    if v is not None and v.upper() not in valid:
+        raise ValueError(f"Invalid trajectory_match_type '{v}'. Valid values: {sorted(valid)}")
+    return v.upper() if v is not None else v
+
+
 class BuiltinMetricDef(BaseModel):
     """A built-in ADK metric, optionally with threshold/judge overrides."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     name: str
     type: Literal["builtin"] = "builtin"
-    threshold: float | None = None
+    threshold: float | None = Field(default=None, ge=0, le=1)
     judge_model: str | None = None
+    trajectory_match_type: str | None = None
+
+    @field_validator("trajectory_match_type")
+    @classmethod
+    def _validate_trajectory_match_type(cls, v: str | None) -> str | None:
+        return _normalize_trajectory_match_type(v)
 
 
 class BaseEvaluatorDef(BaseModel):
     """Shared fields for all executable evaluator definitions."""
 
     name: str
-    threshold: float = 0.5
+    threshold: float = Field(default=0.5, ge=0, le=1)
     timeout: int = Field(default=30, description="Subprocess timeout in seconds.")
     config: dict[str, Any] = Field(default_factory=dict)
     executor: str = Field(default="local", description="Execution environment: 'local' or 'docker' (future).")
@@ -76,7 +92,7 @@ class OpenAIEvalDef(BaseModel):
 
     type: Literal["openai_eval"] = "openai_eval"
     name: str
-    threshold: float = 0.5
+    threshold: float = Field(default=0.5, ge=0, le=1)
     timeout: int = Field(default=120, description="Max seconds to wait for the OpenAI eval run to complete.")
     grader: dict[str, Any] = Field(description="OpenAI grader config passed to testing_criteria.")
 
@@ -94,10 +110,32 @@ class OpenAIEvalDef(BaseModel):
         return v
 
 
-CustomEvaluatorDef = Annotated[
+EvaluatorDef = Annotated[
     BuiltinMetricDef | CodeEvaluatorDef | RemoteEvaluatorDef | OpenAIEvalDef,
     Field(discriminator="type"),
 ]
+
+
+def make_builtin_evaluator_entries(
+    metric_names: list[str] | None,
+    *,
+    judge_model: str | None = None,
+    threshold: float | None = None,
+    trajectory_match_type: str | None = None,
+) -> list[BuiltinMetricDef]:
+    metrics = metric_names if metric_names is not None else ["tool_trajectory_avg_score"]
+
+    evaluators: list[BuiltinMetricDef] = []
+    for name in metrics:
+        evaluators.append(
+            BuiltinMetricDef(
+                name=name,
+                judge_model=judge_model,
+                threshold=threshold,
+                trajectory_match_type=trajectory_match_type,
+            )
+        )
+    return evaluators
 
 
 class EvalParams(BaseModel):
@@ -107,42 +145,24 @@ class EvalParams(BaseModel):
     evaluation.  ``EvalRunConfig`` inherits from this and adds file I/O fields.
     """
 
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="forbid")
 
-    metrics: list[str] = Field(
-        default_factory=lambda: ["tool_trajectory_avg_score"],
-        description="List of built-in metric names to evaluate.",
+    evaluators: list[EvaluatorDef] = Field(
+        default_factory=lambda: [BuiltinMetricDef(name="tool_trajectory_avg_score")],
+        description="Evaluator definitions, including built-in evaluators and custom evaluators.",
     )
 
-    custom_evaluators: list[CustomEvaluatorDef] = Field(
-        default_factory=list,
-        description="Custom evaluator definitions.",
-    )
-
-    judge_model: str | None = Field(
-        default=None,
-        description="LLM model for judge-based metrics.",
-    )
-
-    threshold: float | None = Field(
-        default=None,
-        ge=0,
-        le=1,
-        description="Score threshold for pass/fail (0.0 to 1.0).",
-    )
-
-    trajectory_match_type: str | None = Field(
-        default=None,
-        description="Match type for tool_trajectory_avg_score: 'EXACT', 'IN_ORDER', or 'ANY_ORDER'. Default: EXACT.",
-    )
-
-    @field_validator("trajectory_match_type")
+    @field_validator("evaluators")
     @classmethod
-    def _validate_trajectory_match_type(cls, v: str | None) -> str | None:
-        valid = {"EXACT", "IN_ORDER", "ANY_ORDER"}
-        if v is not None and v.upper() not in valid:
-            raise ValueError(f"Invalid trajectory_match_type '{v}'. Valid values: {sorted(valid)}")
-        return v.upper() if v is not None else v
+    def _validate_evaluators(cls, v: list[EvaluatorDef]) -> list[EvaluatorDef]:
+        if not v:
+            raise ValueError("At least one evaluator is required.")
+        duplicate_names = sorted(name for name, count in Counter(evaluator.name for evaluator in v).items() if count > 1)
+        if duplicate_names:
+            raise ValueError(
+                "Evaluator names must be globally unique. Duplicate names: " + ", ".join(duplicate_names)
+            )
+        return v
 
     max_concurrent_traces: int = Field(
         default=10,
@@ -153,7 +173,7 @@ class EvalParams(BaseModel):
     max_concurrent_evals: int = Field(
         default=5,
         ge=1,
-        description="Maximum number of concurrent metric evaluations (LLM API calls).",
+        description="Maximum number of concurrent evaluator executions (for example LLM API calls).",
     )
 
 

--- a/src/agentevals/config.py
+++ b/src/agentevals/config.py
@@ -157,11 +157,11 @@ class EvalParams(BaseModel):
     def _validate_evaluators(cls, v: list[EvaluatorDef]) -> list[EvaluatorDef]:
         if not v:
             raise ValueError("At least one evaluator is required.")
-        duplicate_names = sorted(name for name, count in Counter(evaluator.name for evaluator in v).items() if count > 1)
+        duplicate_names = sorted(
+            name for name, count in Counter(evaluator.name for evaluator in v).items() if count > 1
+        )
         if duplicate_names:
-            raise ValueError(
-                "Evaluator names must be globally unique. Duplicate names: " + ", ".join(duplicate_names)
-            )
+            raise ValueError("Evaluator names must be globally unique. Duplicate names: " + ", ".join(duplicate_names))
         return v
 
     max_concurrent_traces: int = Field(

--- a/src/agentevals/config.py
+++ b/src/agentevals/config.py
@@ -138,6 +138,34 @@ def make_builtin_evaluator_entries(
     return evaluators
 
 
+def apply_builtin_overrides(
+    evaluators: list[EvaluatorDef],
+    *,
+    judge_model: str | None = None,
+    threshold: float | None = None,
+    trajectory_match_type: str | None = None,
+) -> list[EvaluatorDef]:
+    """Return a new evaluator list with run-level overrides applied to built-ins.
+
+    Non-builtin entries pass through unchanged. Each override is only applied
+    when the corresponding argument is not None, so callers can pass any subset.
+    """
+    updated: list[EvaluatorDef] = []
+    for evaluator in evaluators:
+        if isinstance(evaluator, BuiltinMetricDef):
+            payload = evaluator.model_dump(by_alias=False)
+            if judge_model is not None:
+                payload["judge_model"] = judge_model
+            if threshold is not None:
+                payload["threshold"] = threshold
+            if trajectory_match_type is not None:
+                payload["trajectory_match_type"] = trajectory_match_type
+            updated.append(BuiltinMetricDef.model_validate(payload))
+        else:
+            updated.append(evaluator)
+    return updated
+
+
 class EvalParams(BaseModel):
     """Evaluation parameters independent of how traces are provided.
 

--- a/src/agentevals/custom_evaluators.py
+++ b/src/agentevals/custom_evaluators.py
@@ -441,8 +441,19 @@ async def evaluate_custom_evaluator(
     """
     import inspect as _inspect
 
-    from .config import CodeEvaluatorDef, OpenAIEvalDef, RemoteEvaluatorDef
+    from .builtin_metrics import evaluate_builtin_metric
+    from .config import BuiltinMetricDef, CodeEvaluatorDef, OpenAIEvalDef, RemoteEvaluatorDef
     from .runner import MetricResult
+
+    if isinstance(evaluator_def, BuiltinMetricDef):
+        return await evaluate_builtin_metric(
+            metric_name=evaluator_def.name,
+            actual_invocations=actual_invocations,
+            expected_invocations=expected_invocations,
+            judge_model=evaluator_def.judge_model,
+            threshold=evaluator_def.threshold,
+            match_type=evaluator_def.trajectory_match_type,
+        )
 
     if isinstance(evaluator_def, OpenAIEvalDef):
         from .openai_eval_backend import evaluate_openai_eval

--- a/src/agentevals/eval_config_loader.py
+++ b/src/agentevals/eval_config_loader.py
@@ -25,8 +25,7 @@ _TYPE_TO_MODEL = {
 
 
 def _parse_evaluator_entry(entry: dict[str, Any]) -> EvaluatorDef:
-    """Parse a single evaluator entry from the YAML config.
-    """
+    """Parse a single evaluator entry from the YAML config."""
     if not isinstance(entry, dict):
         raise ValueError(
             f"Each evaluator entry must be a mapping with 'name' and 'type' fields, got {type(entry).__name__}: {entry!r}"

--- a/src/agentevals/eval_config_loader.py
+++ b/src/agentevals/eval_config_loader.py
@@ -66,7 +66,7 @@ def load_eval_config(path: str | Path) -> EvalRunConfig:
 
     legacy_keys = {
         "metrics",
-        "custom_graders",
+        "custom_evaluators",
         "judge_model",
         "threshold",
         "trajectory_match_type",

--- a/src/agentevals/eval_config_loader.py
+++ b/src/agentevals/eval_config_loader.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import Any
 
@@ -11,13 +10,11 @@ import yaml
 from .config import (
     BuiltinMetricDef,
     CodeEvaluatorDef,
-    CustomEvaluatorDef,
     EvalRunConfig,
+    EvaluatorDef,
     OpenAIEvalDef,
     RemoteEvaluatorDef,
 )
-
-logger = logging.getLogger(__name__)
 
 _TYPE_TO_MODEL = {
     "builtin": BuiltinMetricDef,
@@ -27,11 +24,8 @@ _TYPE_TO_MODEL = {
 }
 
 
-def _parse_evaluator_entry(entry: dict[str, Any]) -> tuple[str | None, CustomEvaluatorDef | None]:
+def _parse_evaluator_entry(entry: dict[str, Any]) -> EvaluatorDef:
     """Parse a single evaluator entry from the YAML config.
-
-    Every entry must be a dict with ``name`` and ``type`` fields.
-    Returns (builtin_name, custom_evaluator_def).  Exactly one will be non-None.
     """
     if not isinstance(entry, dict):
         raise ValueError(
@@ -52,22 +46,14 @@ def _parse_evaluator_entry(entry: dict[str, Any]) -> tuple[str | None, CustomEva
         )
 
     model_cls = _TYPE_TO_MODEL[evaluator_type]
-    evaluator_def = model_cls.model_validate(entry)
-
-    if evaluator_type == "builtin":
-        return name, evaluator_def if (
-            evaluator_def.threshold is not None or evaluator_def.judge_model is not None
-        ) else None
-
-    return None, evaluator_def
+    return model_cls.model_validate(entry)
 
 
 def load_eval_config(path: str | Path) -> EvalRunConfig:
     """Load an eval config YAML file and return a partially-filled EvalRunConfig.
 
     The YAML file uses an ``evaluators`` list where each entry is a dict with
-    ``name`` and ``type`` fields.  Built-in entries populate ``metrics``;
-    code/remote entries populate ``custom_evaluators``.
+    ``name`` and ``type`` fields.
     """
     path = Path(path)
     if not path.exists():
@@ -79,44 +65,40 @@ def load_eval_config(path: str | Path) -> EvalRunConfig:
     if not isinstance(data, dict):
         raise ValueError(f"Eval config must be a YAML mapping, got {type(data).__name__}")
 
+    legacy_keys = {
+        "metrics",
+        "custom_graders",
+        "judge_model",
+        "threshold",
+        "trajectory_match_type",
+    }
+    present_legacy_keys = sorted(key for key in legacy_keys if key in data)
+    if present_legacy_keys:
+        raise ValueError(
+            "Legacy eval config keys are no longer supported: "
+            + ", ".join(present_legacy_keys)
+            + ". Use 'evaluators' instead."
+        )
+
     raw_evaluators = data.get("evaluators", [])
     if not isinstance(raw_evaluators, list):
         raise ValueError("'evaluators' must be a list")
 
-    builtin_names: list[str] = []
-    custom_defs: list[CustomEvaluatorDef] = []
-    builtin_overrides: dict[str, BuiltinMetricDef] = {}
-
-    for entry in raw_evaluators:
-        builtin_name, custom_def = _parse_evaluator_entry(entry)
-        if builtin_name:
-            builtin_names.append(builtin_name)
-        if custom_def:
-            if isinstance(custom_def, BuiltinMetricDef):
-                builtin_overrides[custom_def.name] = custom_def
-                if custom_def.name not in builtin_names:
-                    builtin_names.append(custom_def.name)
-            else:
-                custom_defs.append(custom_def)
+    evaluator_defs = [_parse_evaluator_entry(entry) for entry in raw_evaluators]
 
     config = EvalRunConfig(
         trace_files=[],
-        metrics=builtin_names,
-        custom_evaluators=custom_defs,
+        evaluators=evaluator_defs,
     )
 
     if "eval_set" in data:
         config.eval_set_file = str(data["eval_set"])
-    if "judge_model" in data:
-        config.judge_model = data["judge_model"]
-    if "threshold" in data:
-        config.threshold = float(data["threshold"])
-    if "trajectory_match_type" in data:
-        config.trajectory_match_type = data["trajectory_match_type"]
     if "trace_format" in data:
         config.trace_format = data["trace_format"]
-
-    config._builtin_overrides = builtin_overrides  # type: ignore[attr-defined]
+    if "output_format" in data:
+        config.output_format = str(data["output_format"])
+    elif "output" in data:
+        config.output_format = str(data["output"])
 
     return config
 
@@ -124,30 +106,24 @@ def load_eval_config(path: str | Path) -> EvalRunConfig:
 def merge_configs(file_config: EvalRunConfig, cli_config: EvalRunConfig) -> EvalRunConfig:
     """Merge a file-based config with CLI overrides.
 
-    CLI values take precedence for scalar fields.  Metrics lists are merged:
-    CLI ``--metric`` flags are added to the file config's built-in metrics
-    (duplicates removed).
+    CLI values take precedence for scalar fields. Evaluator definitions are
+    merged by evaluator name, with CLI-provided entries replacing file entries
+    of the same identity.
     """
-    merged = file_config.model_copy()
+    merged = file_config.model_copy(deep=True)
 
     if cli_config.trace_files:
         merged.trace_files = cli_config.trace_files
     if cli_config.eval_set_file is not None:
         merged.eval_set_file = cli_config.eval_set_file
-    if cli_config.judge_model is not None:
-        merged.judge_model = cli_config.judge_model
-    if cli_config.threshold is not None:
-        merged.threshold = cli_config.threshold
-    if cli_config.trajectory_match_type is not None:
-        merged.trajectory_match_type = cli_config.trajectory_match_type
     if cli_config.trace_format is not None:
         merged.trace_format = cli_config.trace_format
     if cli_config.output_format != "table":
         merged.output_format = cli_config.output_format
 
-    file_metric_names = set(merged.metrics)
-    for name in cli_config.metrics:
-        if name not in file_metric_names:
-            merged.metrics.append(name)
+    merged_evaluators: dict[str, EvaluatorDef] = {e.name: e for e in merged.evaluators}
+    for evaluator in cli_config.evaluators:
+        merged_evaluators[evaluator.name] = evaluator
+    merged.evaluators = list(merged_evaluators.values())
 
     return merged

--- a/src/agentevals/mcp_server.py
+++ b/src/agentevals/mcp_server.py
@@ -8,7 +8,7 @@ import httpx
 from mcp.server import FastMCP
 from pydantic import BaseModel, Field
 
-from agentevals.config import EvalRunConfig, make_builtin_evaluator_entries
+from agentevals.config import EvalRunConfig, apply_builtin_overrides, make_builtin_evaluator_entries
 from agentevals.runner import run_evaluation
 
 _DEFAULT_SERVER_URL = "http://localhost:8001"
@@ -87,23 +87,6 @@ class EvaluateSessionsResponse(BaseModel):
     golden_session_id: str
     eval_set_id: str
     results: list[SessionEvalResultResponse]
-
-
-def _apply_builtin_overrides(evaluators, *, judge_model=None, threshold=None, trajectory_match_type=None):
-    updated = []
-    for evaluator in evaluators:
-        if getattr(evaluator, "type", None) == "builtin":
-            payload = evaluator.model_dump(by_alias=False)
-            if judge_model is not None:
-                payload["judge_model"] = judge_model
-            if threshold is not None:
-                payload["threshold"] = threshold
-            if trajectory_match_type is not None:
-                payload["trajectory_match_type"] = trajectory_match_type
-            updated.append(type(evaluator).model_validate(payload))
-        else:
-            updated.append(evaluator)
-    return updated
 
 
 # ---------------------------------------------------------------------------
@@ -301,7 +284,7 @@ def create_server(server_url: str | None = None, **fastmcp_kwargs: Any) -> FastM
             elif judge_model is not None or threshold is not None:
                 config = config.model_copy(
                     update={
-                        "evaluators": _apply_builtin_overrides(
+                        "evaluators": apply_builtin_overrides(
                             config.evaluators,
                             judge_model=judge_model,
                             threshold=threshold,

--- a/src/agentevals/mcp_server.py
+++ b/src/agentevals/mcp_server.py
@@ -299,13 +299,15 @@ def create_server(server_url: str | None = None, **fastmcp_kwargs: Any) -> FastM
                 )
                 config = merge_configs(file_config, cli_config)
             elif judge_model is not None or threshold is not None:
-                config = config.model_copy(update={
-                    "evaluators": _apply_builtin_overrides(
-                        config.evaluators,
-                        judge_model=judge_model,
-                        threshold=threshold,
-                    )
-                })
+                config = config.model_copy(
+                    update={
+                        "evaluators": _apply_builtin_overrides(
+                            config.evaluators,
+                            judge_model=judge_model,
+                            threshold=threshold,
+                        )
+                    }
+                )
             if trace_files:
                 config.trace_files = trace_files
             if trace_format is not None:

--- a/src/agentevals/mcp_server.py
+++ b/src/agentevals/mcp_server.py
@@ -8,7 +8,7 @@ import httpx
 from mcp.server import FastMCP
 from pydantic import BaseModel, Field
 
-from agentevals.config import EvalRunConfig
+from agentevals.config import EvalRunConfig, make_builtin_evaluator_entries
 from agentevals.runner import run_evaluation
 
 _DEFAULT_SERVER_URL = "http://localhost:8001"
@@ -87,6 +87,23 @@ class EvaluateSessionsResponse(BaseModel):
     golden_session_id: str
     eval_set_id: str
     results: list[SessionEvalResultResponse]
+
+
+def _apply_builtin_overrides(evaluators, *, judge_model=None, threshold=None, trajectory_match_type=None):
+    updated = []
+    for evaluator in evaluators:
+        if getattr(evaluator, "type", None) == "builtin":
+            payload = evaluator.model_dump(by_alias=False)
+            if judge_model is not None:
+                payload["judge_model"] = judge_model
+            if threshold is not None:
+                payload["threshold"] = threshold
+            if trajectory_match_type is not None:
+                payload["trajectory_match_type"] = trajectory_match_type
+            updated.append(type(evaluator).model_validate(payload))
+        else:
+            updated.append(evaluator)
+    return updated
 
 
 # ---------------------------------------------------------------------------
@@ -219,11 +236,11 @@ def create_server(server_url: str | None = None, **fastmcp_kwargs: Any) -> FastM
         threshold: float | None = None,
         eval_config_file: str | None = None,
     ) -> EvaluateTracesResponse:
-        """Evaluate one or more local agent trace files against selected metrics.
+        """Evaluate one or more local agent trace files against selected evaluators.
 
         This is the primary offline evaluation tool. It loads trace files from disk,
         converts them to the internal invocation format, and runs each requested
-        metric. Does not require the agentevals server to be running.
+        evaluator. Does not require the agentevals server to be running.
 
         Typical workflow:
             1. Call list_metrics to discover available metrics and their requirements.
@@ -266,29 +283,47 @@ def create_server(server_url: str | None = None, **fastmcp_kwargs: Any) -> FastM
                 - warnings: conversion warnings, if any
             - errors: top-level errors (e.g. trace files that failed to load)
         """
-        if metrics is None:
-            metrics = ["tool_trajectory_avg_score"]
         if eval_config_file:
             from agentevals.eval_config_loader import load_eval_config, merge_configs
 
             file_config = load_eval_config(eval_config_file)
-            cli_config = EvalRunConfig(
-                trace_files=trace_files,
-                metrics=metrics,
-                trace_format=trace_format,
-                eval_set_file=eval_set_file,
-                judge_model=judge_model,
-                threshold=threshold,
-            )
-            config = merge_configs(file_config, cli_config)
+            config = file_config
+            if metrics:
+                cli_config = EvalRunConfig(
+                    trace_files=[],
+                    evaluators=make_builtin_evaluator_entries(
+                        metrics,
+                        judge_model=judge_model,
+                        threshold=threshold,
+                    ),
+                )
+                config = merge_configs(file_config, cli_config)
+            elif judge_model is not None or threshold is not None:
+                config = config.model_copy(update={
+                    "evaluators": _apply_builtin_overrides(
+                        config.evaluators,
+                        judge_model=judge_model,
+                        threshold=threshold,
+                    )
+                })
+            if trace_files:
+                config.trace_files = trace_files
+            if trace_format is not None:
+                config.trace_format = trace_format
+            if eval_set_file is not None:
+                config.eval_set_file = eval_set_file
         else:
+            if metrics is None:
+                metrics = ["tool_trajectory_avg_score"]
             config = EvalRunConfig(
                 trace_files=trace_files,
-                metrics=metrics,
+                evaluators=make_builtin_evaluator_entries(
+                    metrics,
+                    judge_model=judge_model,
+                    threshold=threshold,
+                ),
                 trace_format=trace_format,
                 eval_set_file=eval_set_file,
-                judge_model=judge_model,
-                threshold=threshold,
             )
         result = await run_evaluation(config)
         return summarize_run_result(result)
@@ -400,8 +435,10 @@ def create_server(server_url: str | None = None, **fastmcp_kwargs: Any) -> FastM
     async def evaluate_sessions(
         golden_session_id: str,
         metrics: list[str] | None = None,
-        judge_model: str = "gemini-2.5-flash",
         eval_set_id: str | None = None,
+        judge_model: str | None = None,
+        threshold: float | None = None,
+        trajectory_match_type: str | None = None,
     ) -> EvaluateSessionsResponse:
         """Evaluate all completed sessions against a golden reference session.
 
@@ -425,11 +462,15 @@ def create_server(server_url: str | None = None, **fastmcp_kwargs: Any) -> FastM
             metrics: Metric names to evaluate (from list_metrics). Defaults to
                 ["tool_trajectory_avg_score"]. Only metrics that support eval
                 set comparison are meaningful here.
-            judge_model: LLM model for judge-based metrics. Defaults to
-                "gemini-2.5-flash".
             eval_set_id: A label for the eval set built from the golden session.
                 Any string is accepted. If omitted, a default is generated from
                 the golden session ID.
+            judge_model: Optional LLM judge model override for judge-based
+                built-in evaluators.
+            threshold: Optional pass/fail threshold override for built-in
+                evaluators.
+            trajectory_match_type: Optional match type override for
+                "tool_trajectory_avg_score" (EXACT, IN_ORDER, ANY_ORDER).
 
         Returns:
             An EvaluateSessionsResponse with:
@@ -450,8 +491,15 @@ def create_server(server_url: str | None = None, **fastmcp_kwargs: Any) -> FastM
             {
                 "golden_session_id": golden_session_id,
                 "eval_set_id": eval_set_id or f"eval-{golden_session_id[:12]}",
-                "metrics": metrics,
-                "judge_model": judge_model,
+                "evaluators": [
+                    e.model_dump(mode="json", by_alias=True)
+                    for e in make_builtin_evaluator_entries(
+                        metrics,
+                        judge_model=judge_model,
+                        threshold=threshold,
+                        trajectory_match_type=trajectory_match_type,
+                    )
+                ],
             },
         )
         return EvaluateSessionsResponse(

--- a/src/agentevals/run/result_builder.py
+++ b/src/agentevals/run/result_builder.py
@@ -23,9 +23,9 @@ def classify_evaluator(metric_name: str, params: EvalParams) -> EvaluatorType:
     """Look up whether a metric was a built-in or a custom evaluator,
     falling back to ``builtin`` so unknown names round-trip cleanly rather
     than raising during persistence."""
-    for ce in params.custom_evaluators:
-        if ce.name == metric_name:
-            return ce.type
+    for evaluator in params.evaluators:
+        if evaluator.name == metric_name:
+            return evaluator.type
     return "builtin"
 
 

--- a/src/agentevals/run/service.py
+++ b/src/agentevals/run/service.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID, uuid4
 
+from pydantic import ValidationError
+
 from ..config import EvalParams
 from ..runner import RunResult
 from ..storage.models import Run, RunSpec, RunStatus, TraceTarget
@@ -41,6 +43,7 @@ class RunService:
         self._results = results
 
     async def submit(self, *, run_id: UUID | None, spec: RunSpec) -> Run:
+        self._validate_spec(spec)
         run = Run(
             run_id=run_id or uuid4(),
             status=RunStatus.QUEUED,
@@ -50,6 +53,13 @@ class RunService:
         if persisted.run_id == run.run_id and persisted.spec != spec:
             raise RunSubmitConflict(persisted)
         return persisted
+
+    @staticmethod
+    def _validate_spec(spec: RunSpec) -> None:
+        try:
+            EvalParams.model_validate(spec.eval_config or {})
+        except ValidationError as exc:
+            raise ValueError(f"Invalid eval_config: {exc}") from exc
 
     async def get(self, run_id: UUID) -> Run | None:
         return await self._runs.get(run_id)

--- a/src/agentevals/runner.py
+++ b/src/agentevals/runner.py
@@ -14,11 +14,10 @@ from google.adk.evaluation.eval_set import EvalSet
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
-from .builtin_metrics import evaluate_builtin_metric
 from .config import (
-    CustomEvaluatorDef,
     EvalParams,
     EvalRunConfig,
+    EvaluatorDef,
 )
 from .converter import ConversionResult, convert_traces
 from .loader import load_traces
@@ -114,12 +113,8 @@ async def run_evaluation_from_traces(
 
             return await _evaluate_trace(
                 conv_result=conv_result,
-                metrics=config.metrics,
-                custom_evaluators=config.custom_evaluators,
+                evaluators=config.evaluators,
                 eval_set=eval_set,
-                judge_model=config.judge_model,
-                threshold=config.threshold,
-                trajectory_match_type=config.trajectory_match_type,
                 eval_semaphore=eval_semaphore,
                 progress_callback=progress_callback,
                 trace_progress_callback=trace_progress_callback,
@@ -248,17 +243,13 @@ async def run_evaluation(
 
 async def _evaluate_trace(
     conv_result: ConversionResult,
-    metrics: list[str],
-    custom_evaluators: list[CustomEvaluatorDef],
+    evaluators: list[EvaluatorDef],
     eval_set: EvalSet | None,
-    judge_model: str | None,
-    threshold: float | None,
     eval_semaphore: asyncio.Semaphore,
     progress_callback: ProgressCallback | None = None,
     trace_progress_callback: TraceProgressCallback | None = None,
     trace=None,
     performance_metrics: dict[str, Any] | None = None,
-    trajectory_match_type: str | None = None,
 ) -> TraceResult:
     trace_result = TraceResult(
         trace_id=conv_result.trace_id,
@@ -290,23 +281,7 @@ async def _evaluate_trace(
             await trace_progress_callback(trace_result)
         return result
 
-    async def _eval_builtin_with_semaphore(metric_name: str) -> MetricResult:
-        async with eval_semaphore:
-            if progress_callback:
-                await progress_callback(f"Running {metric_name}...")
-            t0 = time.monotonic()
-            result = await evaluate_builtin_metric(
-                metric_name=metric_name,
-                actual_invocations=actual_invocations,
-                expected_invocations=expected_invocations,
-                judge_model=judge_model,
-                threshold=threshold,
-                match_type=trajectory_match_type,
-            )
-            result.duration_ms = (time.monotonic() - t0) * 1000
-        return await _append_result(result)
-
-    async def _eval_custom_with_semaphore(evaluator_def: CustomEvaluatorDef) -> MetricResult:
+    async def _eval_with_semaphore(evaluator_def: EvaluatorDef) -> MetricResult:
         async with eval_semaphore:
             if progress_callback:
                 await progress_callback(f"Running {evaluator_def.name}...")
@@ -322,8 +297,7 @@ async def _evaluate_trace(
             result.duration_ms = (time.monotonic() - t0) * 1000
         return await _append_result(result)
 
-    tasks = [_eval_builtin_with_semaphore(m) for m in metrics]
-    tasks.extend(_eval_custom_with_semaphore(g) for g in custom_evaluators)
+    tasks = [_eval_with_semaphore(evaluator_def) for evaluator_def in evaluators]
 
     await asyncio.gather(*tasks)
 

--- a/tests/api/test_evaluate_persistence.py
+++ b/tests/api/test_evaluate_persistence.py
@@ -51,7 +51,7 @@ class TestEvaluateMultipartSync:
                 r = client.post(
                     "/api/evaluate",
                     files={"trace_files": ("helm.json", f, "application/json")},
-                    data={"config": '{"metrics": ["tool_trajectory_avg_score"]}'},
+                    data={"config": '{"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]}'},
                 )
         assert r.status_code == 200
         assert r.json()["data"].get("runId") is None
@@ -63,7 +63,7 @@ class TestEvaluateMultipartSync:
                 r = client.post(
                     "/api/evaluate",
                     files={"trace_files": ("helm.json", f, "application/json")},
-                    data={"config": '{"metrics": ["tool_trajectory_avg_score"]}'},
+                    data={"config": '{"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]}'},
                 )
         assert r.status_code == 200
         run_id = r.json()["data"]["runId"]
@@ -87,7 +87,7 @@ class TestEvaluateMultipartSync:
                 r = client.post(
                     "/api/evaluate",
                     files={"trace_files": ("helm.json", f, "application/json")},
-                    data={"config": '{"metrics": ["tool_trajectory_avg_score"]}'},
+                    data={"config": '{"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]}'},
                 )
         run_id = r.json()["data"]["runId"]
         results = asyncio.run(repos.results.list_by_run(_uuid(run_id)))
@@ -106,7 +106,7 @@ class TestEvaluateMultipartSync:
                     client.post(
                         "/api/evaluate",
                         files={"trace_files": ("helm.json", f, "application/json")},
-                        data={"config": '{"metrics": ["tool_trajectory_avg_score"]}'},
+                        data={"config": '{"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]}'},
                     )
         runs = asyncio.run(repos.runs.list())
         assert len(runs) == 3
@@ -126,7 +126,7 @@ class TestEvaluateMultipartSync:
                 r = client.post(
                     "/api/evaluate",
                     files={"trace_files": ("helm.json", f, "application/json")},
-                    data={"config": '{"metrics": ["tool_trajectory_avg_score"]}'},
+                    data={"config": '{"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]}'},
                 )
         assert r.status_code == 200
         assert r.json()["data"].get("runId") is None
@@ -142,7 +142,7 @@ class TestEvaluateSseStream:
                     "POST",
                     "/api/evaluate/stream",
                     files={"trace_files": ("helm.json", f, "application/json")},
-                    data={"config": '{"metrics": ["tool_trajectory_avg_score"]}'},
+                    data={"config": '{"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]}'},
                 ) as resp:
                     body = b"".join(resp.iter_bytes()).decode()
         # The done event payload is JSON in the last `data:` block.

--- a/tests/api/test_runs_routes.py
+++ b/tests/api/test_runs_routes.py
@@ -126,6 +126,15 @@ class TestSubmitRun:
             )
         assert r.status_code == 422
 
+    def test_invalid_legacy_eval_config_rejected(self, stubbed_app):
+        app, _ = stubbed_app
+        payload = self._payload()
+        payload["spec"]["evalConfig"] = {"judgeModel": "gemini-2.5-flash"}
+        with TestClient(app) as client:
+            r = client.post("/api/runs", json=payload)
+        assert r.status_code == 422
+        assert "Invalid eval_config" in r.json()["detail"]
+
 
 class TestGetAndListRuns:
     def test_unknown_run_id_returns_404(self, stubbed_app):

--- a/tests/run/test_result_builder.py
+++ b/tests/run/test_result_builder.py
@@ -16,8 +16,8 @@ from agentevals.runner import MetricResult, RunResult, TraceResult
 from agentevals.storage.models import ResultStatus, compute_result_id
 
 
-def _params(custom_evaluators=None) -> EvalParams:
-    return EvalParams(metrics=["m_builtin"], custom_evaluators=custom_evaluators or [])
+def _params(evaluators=None) -> EvalParams:
+    return EvalParams(evaluators=evaluators or [BuiltinMetricDef(name="m_builtin")])
 
 
 def _trace_result(*metrics) -> TraceResult:
@@ -34,14 +34,12 @@ class TestClassifyEvaluator:
         assert classify_evaluator("unknown", _params()) == "builtin"
 
     def test_custom_code_classified_correctly(self):
-        params = _params(custom_evaluators=[CodeEvaluatorDef(name="my_code", path="./e.py")])
+        params = _params(evaluators=[CodeEvaluatorDef(name="my_code", path="./e.py")])
         assert classify_evaluator("my_code", params) == "code"
 
-    def test_builtin_in_metrics_list(self):
-        """Even when explicitly listed in params.metrics, the absence of a
-        matching custom_evaluators entry defaults to 'builtin'. This is
-        intentional: the persisted result row needs a stable type label and
-        custom evaluators are the only ones we can disambiguate by name."""
+    def test_builtin_in_evaluators_list(self):
+        """Builtins remain classified as builtin even though every evaluator now
+        lives in the shared params.evaluators list."""
         assert classify_evaluator("m_builtin", _params()) == "builtin"
 
 

--- a/tests/run/test_service.py
+++ b/tests/run/test_service.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import pytest
 
-from agentevals.config import EvalParams
+from agentevals.config import BuiltinMetricDef, EvalParams
 from agentevals.run.service import RunService, RunSubmitConflict
 from agentevals.runner import MetricResult, RunResult, TraceResult
 from agentevals.storage.models import RunSpec, RunStatus, TraceTarget
@@ -82,7 +82,7 @@ class TestRecordEvalRun:
     """Option A: /api/evaluate synchronously persists runs + results."""
 
     def _params(self) -> EvalParams:
-        return EvalParams(metrics=["m1"])
+        return EvalParams(evaluators=[BuiltinMetricDef(name="m1")])
 
     def _run_result(self, *, errors=None, metrics=None) -> RunResult:
         return RunResult(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -224,7 +224,7 @@ def _make_trace_manager():
 
 
 def _eval_config_json(**overrides) -> str:
-    cfg = {"metrics": ["tool_trajectory_avg_score"]}
+    cfg = {"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]}
     cfg.update(overrides)
     return json.dumps(cfg)
 
@@ -500,11 +500,11 @@ class TestEvaluateTraces:
         )
         assert resp.status_code == 400
 
-    def test_evaluate_empty_metrics(self):
+    def test_evaluate_rejects_legacy_metrics_field(self):
         resp = self.client.post(
             "/api/evaluate",
             files={"trace_files": ("trace.json", io.BytesIO(_make_trace_json()))},
-            data={"config": json.dumps({"metrics": ""})},
+            data={"config": json.dumps({"metrics": ["tool_trajectory_avg_score"]})},
         )
         assert resp.status_code == 400
 
@@ -512,7 +512,11 @@ class TestEvaluateTraces:
         resp = self.client.post(
             "/api/evaluate",
             files={"trace_files": ("trace.json", io.BytesIO(_make_trace_json()))},
-            data={"config": _eval_config_json(threshold=1.5)},
+            data={
+                "config": _eval_config_json(
+                    evaluators=[{"name": "tool_trajectory_avg_score", "type": "builtin", "threshold": 1.5}]
+                )
+            },
         )
         assert resp.status_code == 400
 
@@ -632,7 +636,7 @@ class TestEvaluateJson:
             "/api/evaluate/json",
             json={
                 "traces": _make_otlp_json_payload(),
-                "config": {"metrics": ["tool_trajectory_avg_score"]},
+                "config": {"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]},
             },
         )
         body = _assert_envelope(resp)
@@ -647,8 +651,13 @@ class TestEvaluateJson:
             json={
                 "traces": _make_otlp_json_payload(),
                 "config": {
-                    "metrics": ["hallucinations_v1"],
-                    "judgeModel": "gemini-2.0-flash",
+                    "evaluators": [
+                        {
+                            "name": "hallucinations_v1",
+                            "type": "builtin",
+                            "judgeModel": "gemini-2.0-flash",
+                        }
+                    ],
                     "maxConcurrentTraces": 5,
                 },
             },
@@ -656,7 +665,7 @@ class TestEvaluateJson:
         body = _assert_envelope(resp)
         assert "traceResults" in body["data"]
         call_config = mock_eval.call_args.kwargs["config"]
-        assert call_config.judge_model == "gemini-2.0-flash"
+        assert call_config.evaluators[0].judge_model == "gemini-2.0-flash"
         assert call_config.max_concurrent_traces == 5
 
     def test_evaluate_json_missing_resource_spans(self):
@@ -682,7 +691,7 @@ class TestEvaluateJson:
             "/api/evaluate/json",
             json={
                 "traces": _make_otlp_json_payload(),
-                "config": {"metrics": ["tool_trajectory_avg_score"]},
+                "config": {"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]},
                 "evalSet": {
                     "eval_set_id": "test",
                     "eval_cases": [
@@ -725,6 +734,16 @@ class TestEvaluateJson:
         )
         assert resp.status_code == 422
 
+    def test_evaluate_json_rejects_legacy_metrics_field(self):
+        resp = self.client.post(
+            "/api/evaluate/json",
+            json={
+                "traces": _make_otlp_json_payload(),
+                "config": {"metrics": ["tool_trajectory_avg_score"]},
+            },
+        )
+        assert resp.status_code == 422
+
     @patch("agentevals.api.routes.run_evaluation_from_traces", new_callable=AsyncMock)
     def test_evaluate_json_camel_keys_in_result(self, mock_eval):
         mock_eval.return_value = _make_run_result()
@@ -732,7 +751,7 @@ class TestEvaluateJson:
             "/api/evaluate/json",
             json={
                 "traces": _make_otlp_json_payload(),
-                "config": {"metrics": ["tool_trajectory_avg_score"]},
+                "config": {"evaluators": [{"name": "tool_trajectory_avg_score", "type": "builtin"}]},
             },
         )
         body = resp.json()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import sys
+import textwrap
 from types import ModuleType
 from unittest.mock import AsyncMock
 
 import pytest
+from click.testing import CliRunner
 
 from agentevals import cli
+from agentevals.runner import RunResult
 
 
 class _FakeGrpcServer:
@@ -85,3 +88,78 @@ async def test_run_servers_shares_one_trace_manager_across_live_servers(monkeypa
     assert any(route.path == "/v1/traces" for route in otlp_app.routes)
     assert any(route.path == "/v1/logs" for route in otlp_app.routes)
     fake_stop_grpc.assert_awaited_once_with(fake_grpc_server)
+
+
+def test_run_preserves_config_file_settings_when_flags_omitted(monkeypatch, tmp_path):
+    trace_file = tmp_path / "trace.json"
+    trace_file.write_text("{}")
+    config_file = tmp_path / "eval.yaml"
+    config_file.write_text(
+        textwrap.dedent(
+            """
+            evaluators:
+              - name: tool_trajectory_avg_score
+                type: builtin
+            eval_set: from-config.json
+            trace_format: otlp-json
+            output: json
+            """
+        )
+    )
+
+    captured = {}
+
+    async def fake_run_evaluation(config):
+        captured["config"] = config
+        return RunResult()
+
+    monkeypatch.setattr("agentevals.runner.run_evaluation", fake_run_evaluation)
+    monkeypatch.setattr("agentevals.output.format_results", lambda result, fmt: f"format={fmt}")
+
+    result = CliRunner().invoke(cli.main, ["run", str(trace_file), "--config", str(config_file)])
+
+    assert result.exit_code == 0, result.output
+    assert captured["config"].trace_files == [str(trace_file)]
+    assert captured["config"].eval_set_file == "from-config.json"
+    assert captured["config"].trace_format == "otlp-json"
+    assert captured["config"].output_format == "json"
+    assert "format=json" in result.output
+
+
+def test_run_merges_explicit_metrics_with_config_file(monkeypatch, tmp_path):
+    trace_file = tmp_path / "trace.json"
+    trace_file.write_text("{}")
+    config_file = tmp_path / "eval.yaml"
+    config_file.write_text(
+        textwrap.dedent(
+            """
+            evaluators:
+              - name: tool_trajectory_avg_score
+                type: builtin
+              - name: custom_eval
+                type: code
+                path: ./examples/custom_evaluators/tool_call_checker.py
+            """
+        )
+    )
+
+    captured = {}
+
+    async def fake_run_evaluation(config):
+        captured["config"] = config
+        return RunResult()
+
+    monkeypatch.setattr("agentevals.runner.run_evaluation", fake_run_evaluation)
+    monkeypatch.setattr("agentevals.output.format_results", lambda result, fmt: f"format={fmt}")
+
+    result = CliRunner().invoke(
+        cli.main,
+        ["run", str(trace_file), "--config", str(config_file), "-m", "response_match_score"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [e.name for e in captured["config"].evaluators] == [
+        "tool_trajectory_avg_score",
+        "custom_eval",
+        "response_match_score",
+    ]

--- a/tests/test_eval_config_loader.py
+++ b/tests/test_eval_config_loader.py
@@ -15,7 +15,7 @@ def test_load_eval_config_rejects_legacy_keys(tmp_path):
             """
             metrics:
               - tool_trajectory_avg_score
-            custom_graders:
+            custom_evaluators:
               - name: tool_call_checker
                 type: code
                 path: ./examples/custom_evaluators/tool_call_checker.py

--- a/tests/test_eval_config_loader.py
+++ b/tests/test_eval_config_loader.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from agentevals.config import BuiltinMetricDef, CodeEvaluatorDef, EvalParams, EvalRunConfig
+from agentevals.eval_config_loader import load_eval_config, merge_configs
+
+
+def test_load_eval_config_rejects_legacy_keys(tmp_path):
+    config_file = tmp_path / "legacy_eval.yaml"
+    config_file.write_text(
+        textwrap.dedent(
+            """
+            metrics:
+              - tool_trajectory_avg_score
+            custom_graders:
+              - name: tool_call_checker
+                type: code
+                path: ./examples/custom_evaluators/tool_call_checker.py
+            judge_model: gemini-2.5-flash
+            threshold: 0.8
+            trajectory_match_type: EXACT
+            eval_set: samples/eval_set_helm.json
+            trace_format: otlp-json
+            output: json
+            """
+        )
+    )
+
+    with pytest.raises(ValueError, match="Legacy eval config keys are no longer supported"):
+        load_eval_config(config_file)
+
+
+def test_merge_configs_replaces_evaluators_by_name_and_preserves_file_scalars():
+    file_config = EvalRunConfig(
+        trace_files=["from-file.json"],
+        eval_set_file="from-file-eval-set.json",
+        trace_format="jaeger-json",
+        output_format="json",
+        evaluators=[
+            BuiltinMetricDef(name="tool_trajectory_avg_score", threshold=0.5),
+            CodeEvaluatorDef(name="custom_eval", path="./examples/custom_evaluators/tool_call_checker.py"),
+        ],
+    )
+    cli_config = EvalRunConfig(
+        trace_files=[],
+        evaluators=[
+            BuiltinMetricDef(name="tool_trajectory_avg_score", threshold=0.9),
+            BuiltinMetricDef(name="response_match_score"),
+        ],
+    )
+
+    merged = merge_configs(file_config, cli_config)
+
+    assert merged.eval_set_file == "from-file-eval-set.json"
+    assert merged.trace_format == "jaeger-json"
+    assert merged.output_format == "json"
+    assert [(e.name, e.type) for e in merged.evaluators] == [
+        ("tool_trajectory_avg_score", "builtin"),
+        ("custom_eval", "code"),
+        ("response_match_score", "builtin"),
+    ]
+    tool_trajectory = next(e for e in merged.evaluators if e.name == "tool_trajectory_avg_score")
+    assert tool_trajectory.threshold == 0.9
+
+
+def test_eval_params_reject_duplicate_evaluator_names():
+    with pytest.raises(ValueError, match="globally unique"):
+        EvalParams(
+            evaluators=[
+                BuiltinMetricDef(name="duplicate_name"),
+                CodeEvaluatorDef(name="duplicate_name", path="./examples/custom_evaluators/tool_call_checker.py"),
+            ]
+        )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15,6 +15,7 @@ from agentevals.mcp_server import (
     SummarizeSessionResponse,
     ToolCallResponse,
     TraceEvalResponse,
+    create_server,
     summarize_run_result,
 )
 from agentevals.runner import MetricResult, RunResult, TraceResult
@@ -340,3 +341,62 @@ class TestSummarizeSessionResponse:
     def test_tool_call_default_args(self):
         tc = ToolCallResponse(tool="my_tool")
         assert tc.args == {}
+
+
+@pytest.mark.asyncio
+async def test_evaluate_sessions_posts_builtin_evaluator_overrides(monkeypatch):
+    captured = {}
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "data": {
+                    "goldenSessionId": "golden-1",
+                    "evalSetId": "eval-golden-1",
+                    "results": [],
+                },
+                "error": None,
+            }
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, json):
+            captured["url"] = url
+            captured["json"] = json
+            return _FakeResponse()
+
+    monkeypatch.setattr("agentevals.mcp_server.httpx.AsyncClient", _FakeAsyncClient)
+
+    server = create_server()
+    await server.call_tool(
+        "evaluate_sessions",
+        {
+            "golden_session_id": "golden-1",
+            "metrics": ["final_response_match_v2"],
+            "judge_model": "gemini-2.5-flash",
+            "threshold": 0.9,
+            "trajectory_match_type": "IN_ORDER",
+        },
+    )
+
+    assert captured["url"].endswith("/api/streaming/evaluate-sessions")
+    assert captured["json"]["evaluators"] == [
+        {
+            "name": "final_response_match_v2",
+            "type": "builtin",
+            "threshold": 0.9,
+            "judgeModel": "gemini-2.5-flash",
+            "trajectoryMatchType": "IN_ORDER",
+        }
+    ]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from agentevals.config import EvalRunConfig
+from agentevals.config import BuiltinMetricDef, EvalRunConfig
 from agentevals.converter import convert_traces
 from agentevals.loader.base import Span, Trace
 from agentevals.runner import _evaluate_trace, load_eval_set, run_evaluation
@@ -112,7 +112,7 @@ class TestRunner:
         config = EvalRunConfig(
             trace_files=[HELM_TRACE],
             eval_set_file=EVAL_SET,
-            metrics=["tool_trajectory_avg_score"],
+            evaluators=[BuiltinMetricDef(name="tool_trajectory_avg_score")],
         )
         result = asyncio.run(run_evaluation(config))
 
@@ -135,7 +135,7 @@ class TestRunner:
         """Trajectory metric without eval set should report a clear error."""
         config = EvalRunConfig(
             trace_files=[HELM_TRACE],
-            metrics=["tool_trajectory_avg_score"],
+            evaluators=[BuiltinMetricDef(name="tool_trajectory_avg_score")],
         )
         result = asyncio.run(run_evaluation(config))
 
@@ -148,7 +148,7 @@ class TestRunner:
     def test_bad_trace_file(self):
         config = EvalRunConfig(
             trace_files=["/nonexistent/file.json"],
-            metrics=["tool_trajectory_avg_score"],
+            evaluators=[BuiltinMetricDef(name="tool_trajectory_avg_score")],
         )
         result = asyncio.run(run_evaluation(config))
         assert len(result.errors) >= 1
@@ -171,7 +171,7 @@ class TestRunner:
         config = EvalRunConfig(
             trace_files=[HELM_3_TRACE],
             eval_set_file=EVAL_SET,
-            metrics=["tool_trajectory_avg_score"],
+            evaluators=[BuiltinMetricDef(name="tool_trajectory_avg_score")],
         )
         result = asyncio.run(run_evaluation(config))
 
@@ -207,7 +207,10 @@ class TestRunner:
         config = EvalRunConfig(
             trace_files=[HELM_TRACE],
             eval_set_file=EVAL_SET,
-            metrics=["tool_trajectory_avg_score", "tool_trajectory_avg_score"],
+            evaluators=[
+                BuiltinMetricDef(name="tool_trajectory_avg_score"),
+                BuiltinMetricDef(name="response_match_score"),
+            ],
         )
         result = asyncio.run(run_evaluation(config))
 
@@ -220,7 +223,7 @@ class TestRunner:
         config = EvalRunConfig(
             trace_files=[HELM_TRACE],
             eval_set_file=EVAL_SET,
-            metrics=["tool_trajectory_avg_score"],
+            evaluators=[BuiltinMetricDef(name="tool_trajectory_avg_score")],
         )
         result = asyncio.run(run_evaluation(config))
         output = format_results(result, fmt="json")
@@ -236,7 +239,7 @@ class TestRunner:
         config = EvalRunConfig(
             trace_files=[HELM_TRACE, "/nonexistent/file.json"],
             eval_set_file=EVAL_SET,
-            metrics=["tool_trajectory_avg_score"],
+            evaluators=[BuiltinMetricDef(name="tool_trajectory_avg_score")],
         )
         result = asyncio.run(run_evaluation(config))
         assert len(result.trace_results) >= 1
@@ -276,12 +279,14 @@ class TestTrajectoryMatchType:
         return asyncio.run(
             _evaluate_trace(
                 conv_result=conv_result,
-                metrics=["tool_trajectory_avg_score"],
-                custom_evaluators=[],
+                evaluators=[
+                    BuiltinMetricDef(
+                        name="tool_trajectory_avg_score",
+                        threshold=0.5,
+                        trajectory_match_type=match_type,
+                    )
+                ],
                 eval_set=eval_set,
-                judge_model=None,
-                threshold=0.5,
-                trajectory_match_type=match_type,
                 eval_semaphore=asyncio.Semaphore(1),
             )
         )
@@ -300,3 +305,33 @@ class TestTrajectoryMatchType:
         mr = self._run("IN_ORDER", tmp_path).metric_results[0]
         assert mr.score == 0.0
         assert mr.eval_status == "FAILED"
+
+
+class TestBuiltinCustomEvaluatorOverrides:
+    def test_builtin_custom_evaluator_uses_per_evaluator_match_type(self, tmp_path):
+        conv_result = convert_traces([_make_tool_trace(["helm_get_release", "helm_list_releases"])])[0]
+
+        eval_set_path = tmp_path / "eval_set.json"
+        eval_set_path.write_text(json.dumps(_make_eval_set_json(["helm_list_releases", "helm_get_release"])))
+        eval_set = load_eval_set(str(eval_set_path))
+
+        trace_result = asyncio.run(
+            _evaluate_trace(
+                conv_result=conv_result,
+                evaluators=[
+                    BuiltinMetricDef(
+                        name="tool_trajectory_avg_score",
+                        threshold=0.5,
+                        trajectory_match_type="ANY_ORDER",
+                    )
+                ],
+                eval_set=eval_set,
+                eval_semaphore=asyncio.Semaphore(1),
+            )
+        )
+
+        assert len(trace_result.metric_results) == 1
+        mr = trace_result.metric_results[0]
+        assert mr.metric_name == "tool_trajectory_avg_score"
+        assert mr.score == 1.0
+        assert mr.eval_status == "PASSED"

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1,4 +1,11 @@
-import type { RunResult, EvalConfig, TraceResult, MetricMetadata, StandardResponse, ConvertTracesResponse } from '../lib/types';
+import type {
+  RunResult,
+  EvalConfig,
+  TraceResult,
+  MetricMetadata,
+  StandardResponse,
+  ConvertTracesResponse,
+} from '../lib/types';
 import { config } from '../config';
 
 const API_BASE_URL = `${config.api.baseUrl}/api`;

--- a/ui/src/components/bug-report/BugReportModal.tsx
+++ b/ui/src/components/bug-report/BugReportModal.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Download, X, Loader2 } from 'lucide-react';
 import { useTraceContext } from '../../context/TraceContext';
 import type { TraceState } from '../../context/TraceContext';
 import { generateBugReport } from '../../api/client';
+import { buildEvalConfig } from '../../lib/eval-config';
 import { getConsoleLogs } from '../../lib/console-capture';
 import { getNetworkErrors } from '../../lib/network-capture';
 
@@ -12,6 +13,13 @@ interface BugReportModalProps {
 }
 
 function serializeAppState(state: TraceState): Record<string, unknown> {
+  const evalConfig = buildEvalConfig({
+    selectedEvaluatorNames: state.selectedEvaluatorNames,
+    judgeModel: state.judgeModel,
+    threshold: state.threshold,
+    trajectoryMatchType: state.trajectoryMatchType,
+  });
+
   return {
     currentView: state.currentView,
     evaluationOrigin: state.evaluationOrigin,
@@ -19,9 +27,11 @@ function serializeAppState(state: TraceState): Record<string, unknown> {
     version: state.version,
     isEvaluating: state.isEvaluating,
     progressMessage: state.progressMessage,
-    selectedMetrics: state.selectedMetrics,
+    selectedEvaluatorNames: state.selectedEvaluatorNames,
     judgeModel: state.judgeModel,
     threshold: state.threshold,
+    trajectoryMatchType: state.trajectoryMatchType,
+    evalConfig,
     errors: state.errors,
     traceFileCount: state.traceFiles.length,
     hasEvalSetFile: state.evalSetFile !== null,

--- a/ui/src/components/dashboard/DashboardView.tsx
+++ b/ui/src/components/dashboard/DashboardView.tsx
@@ -193,7 +193,7 @@ export const DashboardView: React.FC = () => {
 
           <TraceTable
             rows={Array.from(state.tableRows.values())}
-            selectedMetrics={state.selectedMetrics}
+            selectedEvaluatorNames={state.selectedEvaluatorNames}
             threshold={state.threshold}
             onRowClick={handleTraceClick}
             onRowHover={handleRowHover}

--- a/ui/src/components/dashboard/TraceTable.tsx
+++ b/ui/src/components/dashboard/TraceTable.tsx
@@ -8,7 +8,7 @@ import { formatTimestamp } from '../../lib/utils';
 
 interface TraceTableProps {
   rows: TraceTableRow[];
-  selectedMetrics: string[];
+  selectedEvaluatorNames: string[];
   threshold: number;
   onRowClick: (traceId: string) => void;
   onRowHover?: (traceId: string | null) => void;
@@ -154,7 +154,7 @@ const extractText = (parts: any[]): string => {
 
 export const TraceTable: React.FC<TraceTableProps> = ({
   rows,
-  selectedMetrics,
+  selectedEvaluatorNames,
   threshold,
   onRowClick,
   onRowHover,
@@ -292,7 +292,7 @@ export const TraceTable: React.FC<TraceTableProps> = ({
         );
       },
     },
-    ...selectedMetrics.map((metricName) => ({
+    ...selectedEvaluatorNames.map((metricName) => ({
       title: metricName.replace(/_/g, ' ').toUpperCase(),
       key: metricName,
       width: 160,

--- a/ui/src/components/inspector/ComparisonPanel.tsx
+++ b/ui/src/components/inspector/ComparisonPanel.tsx
@@ -17,7 +17,7 @@ interface ComparisonPanelProps {
   expectedInvocation: Invocation | null;
   metricResults: MetricResult[];
   threshold: number;
-  selectedMetrics: string[];
+  selectedEvaluatorNames: string[];
   isEvaluating: boolean;
   performanceMetrics?: PerformanceMetrics;
   traceInfo?: TraceInfo;
@@ -30,7 +30,7 @@ export const ComparisonPanel: React.FC<ComparisonPanelProps> = ({
   expectedInvocation,
   metricResults,
   threshold,
-  selectedMetrics,
+  selectedEvaluatorNames,
   isEvaluating,
   performanceMetrics,
   traceInfo,
@@ -78,7 +78,7 @@ export const ComparisonPanel: React.FC<ComparisonPanelProps> = ({
           expectedInvocation={expectedInvocation}
           actualInvocation={actualInvocation}
           threshold={threshold}
-          selectedMetrics={selectedMetrics}
+          selectedEvaluatorNames={selectedEvaluatorNames}
           isEvaluating={isEvaluating}
           allActualInvocations={allActualInvocations}
           allExpectedInvocations={allExpectedInvocations}

--- a/ui/src/components/inspector/InspectorHeader.tsx
+++ b/ui/src/components/inspector/InspectorHeader.tsx
@@ -85,7 +85,7 @@ export const InspectorHeader: React.FC<InspectorHeaderProps> = ({
               <span css={metadataValueStyles}>{traceResult.numInvocations}</span>
             </span>
             <span css={metadataItemStyles}>
-              <span css={metadataLabelStyles}>Metrics:</span>
+              <span css={metadataLabelStyles}>Results:</span>
               <span css={metadataValueStyles}>{traceResult.metricResults.length}</span>
             </span>
             {traceResult.conversionWarnings.length > 0 && (

--- a/ui/src/components/inspector/InspectorView.tsx
+++ b/ui/src/components/inspector/InspectorView.tsx
@@ -208,7 +208,7 @@ export const InspectorView: React.FC = () => {
       expectedInvocation={expectedInvocation}
       metricResults={traceResult.metricResults}
       threshold={state.threshold}
-      selectedMetrics={state.selectedMetrics}
+      selectedEvaluatorNames={state.selectedEvaluatorNames}
       isEvaluating={state.isEvaluating}
       performanceMetrics={traceResult.performanceMetrics}
       traceInfo={{

--- a/ui/src/components/inspector/MetricResultsSection.tsx
+++ b/ui/src/components/inspector/MetricResultsSection.tsx
@@ -8,18 +8,18 @@ import { TrajectoryComparisonDetails } from './TrajectoryComparisonDetails';
 interface MetricResultsSectionProps {
   metricResults: MetricResult[];
   threshold: number;
-  selectedMetrics?: string[];
+  selectedEvaluatorNames?: string[];
   isEvaluating?: boolean;
 }
 
 export const MetricResultsSection: React.FC<MetricResultsSectionProps> = ({
   metricResults,
   threshold,
-  selectedMetrics = [],
+  selectedEvaluatorNames = [],
   isEvaluating = false,
 }) => {
   const metricResultsMap = new Map(metricResults.map(mr => [mr.metricName, mr]));
-  const metricsToShow = selectedMetrics.length > 0 ? selectedMetrics : metricResults.map(mr => mr.metricName);
+  const metricsToShow = selectedEvaluatorNames.length > 0 ? selectedEvaluatorNames : metricResults.map(mr => mr.metricName);
 
   return (
     <div css={containerStyles}>

--- a/ui/src/components/inspector/MetricsComparisonSection.tsx
+++ b/ui/src/components/inspector/MetricsComparisonSection.tsx
@@ -9,7 +9,7 @@ interface MetricsComparisonSectionProps {
   expectedInvocation: Invocation | null;
   actualInvocation: Invocation | null;
   threshold: number;
-  selectedMetrics: string[];
+  selectedEvaluatorNames: string[];
   isEvaluating: boolean;
   allActualInvocations?: Invocation[];
   allExpectedInvocations?: Invocation[];
@@ -20,7 +20,7 @@ export const MetricsComparisonSection: React.FC<MetricsComparisonSectionProps> =
   expectedInvocation,
   actualInvocation,
   threshold,
-  selectedMetrics,
+  selectedEvaluatorNames,
   isEvaluating,
   allActualInvocations,
   allExpectedInvocations,
@@ -208,7 +208,7 @@ export const MetricsComparisonSection: React.FC<MetricsComparisonSectionProps> =
   };
 
   const metricResultsMap = new Map(metricResults.map(mr => [mr.metricName, mr]));
-  const metricsToShow = selectedMetrics.length > 0 ? selectedMetrics : metricResults.map(mr => mr.metricName);
+  const metricsToShow = selectedEvaluatorNames.length > 0 ? selectedEvaluatorNames : metricResults.map(mr => mr.metricName);
 
   const getStatusIcon = (status: string) => {
     switch (status) {
@@ -226,7 +226,7 @@ export const MetricsComparisonSection: React.FC<MetricsComparisonSectionProps> =
   return (
     <div css={sectionContainerStyles}>
       <div css={sectionHeaderStyles}>
-        <h3>Metrics Overview</h3>
+        <h3>Evaluator Results Overview</h3>
         <span css={thresholdBadgeStyles}>Threshold: {threshold}</span>
       </div>
 

--- a/ui/src/components/upload/MetricSelector.tsx
+++ b/ui/src/components/upload/MetricSelector.tsx
@@ -5,8 +5,8 @@ import { AVAILABLE_METRICS, type MetricMetadata } from '../../lib/types';
 import { listMetrics } from '../../api/client';
 
 interface MetricSelectorProps {
-  selectedMetrics: string[];
-  onToggleMetric: (metric: string) => void;
+  selectedEvaluatorNames: string[];
+  onToggleEvaluatorName: (evaluatorName: string) => void;
   loadFromAPI?: boolean;
 }
 
@@ -128,6 +128,12 @@ const selectorStyle = css`
     border-top: 1px solid var(--border-default);
   }
 
+  .selector-note {
+    margin-top: 10px;
+    font-size: 11px;
+    color: var(--text-secondary);
+  }
+
   .ant-checkbox-wrapper {
     color: var(--text-primary);
   }
@@ -140,12 +146,18 @@ const selectorStyle = css`
 
 let cachedMetrics: MetricMetadata[] | null = null;
 
+function isSupportedBuiltinMetric(metric: MetricMetadata): boolean {
+  return metric.working !== false && metric.requiresRubrics !== true;
+}
+
 export const MetricSelector: React.FC<MetricSelectorProps> = ({
-  selectedMetrics,
-  onToggleMetric,
+  selectedEvaluatorNames,
+  onToggleEvaluatorName,
   loadFromAPI = false,
 }) => {
   const [metrics, setMetrics] = useState<MetricMetadata[]>(cachedMetrics ?? AVAILABLE_METRICS);
+  const supportedMetrics = metrics.filter(isSupportedBuiltinMetric);
+  const unsupportedCount = metrics.length - supportedMetrics.length;
 
   useEffect(() => {
     if (!loadFromAPI || cachedMetrics) return;
@@ -163,7 +175,7 @@ export const MetricSelector: React.FC<MetricSelectorProps> = ({
     return () => { cancelled = true; };
   }, [loadFromAPI]);
 
-  const categorizedMetrics = metrics.reduce(
+  const categorizedSupportedMetrics = supportedMetrics.reduce(
     (acc, metric) => {
       if (!acc[metric.category]) {
         acc[metric.category] = [];
@@ -175,23 +187,23 @@ export const MetricSelector: React.FC<MetricSelectorProps> = ({
   );
 
   const handleSelectAll = () => {
-    metrics.forEach((metric) => {
-      if (!selectedMetrics.includes(metric.name)) {
-        onToggleMetric(metric.name);
+    supportedMetrics.forEach((metric) => {
+      if (!selectedEvaluatorNames.includes(metric.name)) {
+        onToggleEvaluatorName(metric.name);
       }
     });
   };
 
   const handleClearAll = () => {
-    selectedMetrics.forEach((metric) => {
-      onToggleMetric(metric);
+    selectedEvaluatorNames.forEach((metric) => {
+      onToggleEvaluatorName(metric);
     });
   };
 
   return (
     <div css={selectorStyle}>
       <div className="metric-categories">
-        {Object.entries(categorizedMetrics).map(([category, metrics]) => (
+        {Object.entries(categorizedSupportedMetrics).map(([category, metrics]) => (
           <div key={category} className="metric-category">
             <div className="category-title">{category}</div>
             <div className="metric-list">
@@ -199,8 +211,8 @@ export const MetricSelector: React.FC<MetricSelectorProps> = ({
                 <div key={metric.name} className="metric-item">
                   <div className="metric-row">
                     <Checkbox
-                      checked={selectedMetrics.includes(metric.name)}
-                      onChange={() => onToggleMetric(metric.name)}
+                      checked={selectedEvaluatorNames.includes(metric.name)}
+                      onChange={() => onToggleEvaluatorName(metric.name)}
                     >
                       <span className="metric-name">{metric.name}</span>
                     </Checkbox>
@@ -238,6 +250,12 @@ export const MetricSelector: React.FC<MetricSelectorProps> = ({
           Clear All
         </Button>
       </div>
+      {unsupportedCount > 0 && (
+        <div className="selector-note">
+          Hidden {unsupportedCount} unsupported built-in evaluator{unsupportedCount === 1 ? '' : 's'} that require
+          rubric configuration or are marked incomplete.
+        </div>
+      )}
     </div>
   );
 };

--- a/ui/src/components/upload/MetricSelector.tsx
+++ b/ui/src/components/upload/MetricSelector.tsx
@@ -146,18 +146,13 @@ const selectorStyle = css`
 
 let cachedMetrics: MetricMetadata[] | null = null;
 
-function isSupportedBuiltinMetric(metric: MetricMetadata): boolean {
-  return metric.working !== false && metric.requiresRubrics !== true;
-}
-
 export const MetricSelector: React.FC<MetricSelectorProps> = ({
   selectedEvaluatorNames,
   onToggleEvaluatorName,
   loadFromAPI = false,
 }) => {
   const [metrics, setMetrics] = useState<MetricMetadata[]>(cachedMetrics ?? AVAILABLE_METRICS);
-  const supportedMetrics = metrics.filter(isSupportedBuiltinMetric);
-  const unsupportedCount = metrics.length - supportedMetrics.length;
+  const hasCaveatedMetrics = metrics.some((m) => m.requiresRubrics === true || m.working === false);
 
   useEffect(() => {
     if (!loadFromAPI || cachedMetrics) return;
@@ -175,7 +170,7 @@ export const MetricSelector: React.FC<MetricSelectorProps> = ({
     return () => { cancelled = true; };
   }, [loadFromAPI]);
 
-  const categorizedSupportedMetrics = supportedMetrics.reduce(
+  const categorizedMetrics = metrics.reduce(
     (acc, metric) => {
       if (!acc[metric.category]) {
         acc[metric.category] = [];
@@ -187,7 +182,7 @@ export const MetricSelector: React.FC<MetricSelectorProps> = ({
   );
 
   const handleSelectAll = () => {
-    supportedMetrics.forEach((metric) => {
+    metrics.forEach((metric) => {
       if (!selectedEvaluatorNames.includes(metric.name)) {
         onToggleEvaluatorName(metric.name);
       }
@@ -203,7 +198,7 @@ export const MetricSelector: React.FC<MetricSelectorProps> = ({
   return (
     <div css={selectorStyle}>
       <div className="metric-categories">
-        {Object.entries(categorizedSupportedMetrics).map(([category, metrics]) => (
+        {Object.entries(categorizedMetrics).map(([category, metrics]) => (
           <div key={category} className="metric-category">
             <div className="category-title">{category}</div>
             <div className="metric-list">
@@ -250,10 +245,9 @@ export const MetricSelector: React.FC<MetricSelectorProps> = ({
           Clear All
         </Button>
       </div>
-      {unsupportedCount > 0 && (
+      {hasCaveatedMetrics && (
         <div className="selector-note">
-          Hidden {unsupportedCount} unsupported built-in evaluator{unsupportedCount === 1 ? '' : 's'} that require
-          rubric configuration or are marked incomplete.
+          Some evaluators require rubric configuration or are work-in-progress; see badges.
         </div>
       )}
     </div>

--- a/ui/src/components/upload/UploadView.tsx
+++ b/ui/src/components/upload/UploadView.tsx
@@ -190,7 +190,7 @@ export const UploadView: React.FC = () => {
 
   const canRunEvaluation =
     state.traceFiles.length > 0 &&
-    state.selectedMetrics.length > 0 &&
+    state.selectedEvaluatorNames.length > 0 &&
     !state.isLoadingMetadata;
 
   return (
@@ -461,10 +461,10 @@ export const UploadView: React.FC = () => {
         )}
 
         <div className="section metrics-section">
-          <div className="section-title">Metrics Configuration</div>
+          <div className="section-title">Built-in Evaluator Configuration</div>
           <MetricSelector
-            selectedMetrics={state.selectedMetrics}
-            onToggleMetric={actions.toggleMetric}
+            selectedEvaluatorNames={state.selectedEvaluatorNames}
+            onToggleEvaluatorName={actions.toggleEvaluatorName}
             loadFromAPI={true}
           />
         </div>
@@ -527,7 +527,7 @@ export const UploadView: React.FC = () => {
             </span>
           </div>
 
-          {state.selectedMetrics.includes('tool_trajectory_avg_score') && (
+          {state.selectedEvaluatorNames.includes('tool_trajectory_avg_score') && (
             <div className="setting-item" style={{ marginTop: 10 }}>
               <label className="setting-label">Trajectory Match Type</label>
               <Select

--- a/ui/src/context/TraceContext.tsx
+++ b/ui/src/context/TraceContext.tsx
@@ -12,7 +12,7 @@ export interface TraceState {
   // Upload state
   traceFiles: File[];
   evalSetFile: File | null;
-  selectedMetrics: string[];
+  selectedEvaluatorNames: string[];
   judgeModel: string;
   threshold: number;
   trajectoryMatchType: string;
@@ -52,7 +52,7 @@ export interface TraceContextType {
   actions: {
     setTraceFiles: (files: File[]) => Promise<void>;
     setEvalSet: (file: File | null) => void;
-    toggleMetric: (metric: string) => void;
+    toggleEvaluatorName: (evaluatorName: string) => void;
     setJudgeModel: (model: string) => void;
     setThreshold: (threshold: number) => void;
     setTrajectoryMatchType: (matchType: string) => void;

--- a/ui/src/context/TraceProvider.tsx
+++ b/ui/src/context/TraceProvider.tsx
@@ -2,8 +2,9 @@ import React, { useState, useMemo, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import { TraceContext } from './TraceContext';
 import type { TraceState } from './TraceContext';
-import type { ViewType, EvalSet, EvalSetMetadata, EvalCase, LiveSession, AnnotationQueue, Annotation } from '../lib/types';
+import type { ViewType, EvalConfig, EvalSet, EvalSetMetadata, EvalCase, LiveSession, AnnotationQueue, Annotation } from '../lib/types';
 import { evaluateTracesStreaming, convertTraces, getConfig, healthCheck } from '../api/client';
+import { buildEvalConfig } from '../lib/eval-config';
 
 interface TraceProviderProps {
   children: ReactNode;
@@ -13,7 +14,7 @@ export const TraceProvider: React.FC<TraceProviderProps> = ({ children }) => {
   const [state, setState] = useState<TraceState>({
     traceFiles: [],
     evalSetFile: null,
-    selectedMetrics: ['tool_trajectory_avg_score'],
+    selectedEvaluatorNames: ['tool_trajectory_avg_score'],
     judgeModel: 'gemini-2.5-flash',
     threshold: 0.8,
     trajectoryMatchType: 'EXACT',
@@ -81,12 +82,12 @@ export const TraceProvider: React.FC<TraceProviderProps> = ({ children }) => {
       setEvalSet: (file: File | null) =>
         setState((prev) => ({ ...prev, evalSetFile: file })),
 
-      toggleMetric: (metric: string) =>
+      toggleEvaluatorName: (evaluatorName: string) =>
         setState((prev) => ({
           ...prev,
-          selectedMetrics: prev.selectedMetrics.includes(metric)
-            ? prev.selectedMetrics.filter((m) => m !== metric)
-            : [...prev.selectedMetrics, metric],
+          selectedEvaluatorNames: prev.selectedEvaluatorNames.includes(evaluatorName)
+            ? prev.selectedEvaluatorNames.filter((name) => name !== evaluatorName)
+            : [...prev.selectedEvaluatorNames, evaluatorName],
         })),
 
       setJudgeModel: (model: string) =>
@@ -130,15 +131,17 @@ export const TraceProvider: React.FC<TraceProviderProps> = ({ children }) => {
         }));
 
         try {
+          const evalConfig: EvalConfig = buildEvalConfig({
+            selectedEvaluatorNames: state.selectedEvaluatorNames,
+            judgeModel: state.judgeModel,
+            threshold: state.threshold,
+            trajectoryMatchType: state.trajectoryMatchType,
+          });
+
           await evaluateTracesStreaming(
             state.traceFiles,
             state.evalSetFile,
-            {
-              metrics: state.selectedMetrics,
-              judgeModel: state.judgeModel,
-              threshold: state.threshold,
-              trajectoryMatchType: state.trajectoryMatchType,
-            },
+            evalConfig,
             (message) => {
               setState((prev) => ({ ...prev, progressMessage: message }));
             },
@@ -155,7 +158,7 @@ export const TraceProvider: React.FC<TraceProviderProps> = ({ children }) => {
                   existingMetrics.set(mr.metricName, mr);
                 });
 
-                const allMetricsComplete = prev.selectedMetrics.length === partialResult.metricResults.length;
+                const allMetricsComplete = prev.selectedEvaluatorNames.length === partialResult.metricResults.length;
 
                 newRows.set(traceId, {
                   traceId,
@@ -404,7 +407,7 @@ export const TraceProvider: React.FC<TraceProviderProps> = ({ children }) => {
           };
         }),
     }),
-    [state.traceFiles, state.traceMetadata, state.evalSetFile, state.selectedMetrics, state.judgeModel, state.threshold, state.trajectoryMatchType]
+    [state.traceFiles, state.traceMetadata, state.evalSetFile, state.selectedEvaluatorNames, state.judgeModel, state.threshold, state.trajectoryMatchType]
   );
 
   return (

--- a/ui/src/lib/eval-config.ts
+++ b/ui/src/lib/eval-config.ts
@@ -1,0 +1,25 @@
+import type { EvalConfig } from './types';
+
+interface BuildEvalConfigParams {
+  selectedEvaluatorNames: string[];
+  judgeModel: string;
+  threshold: number;
+  trajectoryMatchType: string;
+}
+
+export function buildEvalConfig({
+  selectedEvaluatorNames,
+  judgeModel,
+  threshold,
+  trajectoryMatchType,
+}: BuildEvalConfigParams): EvalConfig {
+  return {
+    evaluators: selectedEvaluatorNames.map((evaluatorName) => ({
+      type: 'builtin',
+      name: evaluatorName,
+      judgeModel,
+      threshold,
+      trajectoryMatchType,
+    })),
+  };
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -202,12 +202,15 @@ export interface TraceTableRow {
   annotation?: Annotation;
 }
 
-// Configuration
+// Evaluation API config
 export interface EvalConfig {
-  metrics: string[];
-  judgeModel: string;
-  threshold: number;
-  trajectoryMatchType?: string;
+  evaluators: Array<{
+    type: 'builtin';
+    name: string;
+    judgeModel?: string;
+    threshold?: number;
+    trajectoryMatchType?: string;
+  }>;
 }
 
 // EvalSet types


### PR DESCRIPTION
  > [!WARNING]
  > **Breaking change.** The eval config shape has changed. Existing
  > YAML config files, JSON API payloads, and MCP `evaluate-sessions`
  > requests need migration. See the migration guide below.

Previously we had a list of strings (`metrics`) and separate `custom_evaluators` field. this meant that built-in metrics would be provided through the `metrics` value as a name, and only run-level configuration would be applied -- i.e. there was not way to configure per-builtin-evaluator metrics. 

The evaluation config now requires `evaluators` and `agentevals` now accepts a single canonical evaluation config field: `evaluators`.

The legacy `metrics` field has been removed, and legacy top-level config shapes are no longer accepted. Requests and config files must now define built-in and custom evaluators uniformly under `evaluators[]`.
Before:
```json
{
  "metrics": ["tool_trajectory_avg_score"]
}
```
After:

```json
{
  "evaluators": [
    { "name": "tool_trajectory_avg_score", "type": "builtin" }
  ]
}
```
This also means older legacy config fields such as customEvaluators and top-level builtin overrides like judgeModel, threshold, and trajectoryMatchType must be migrated into the corresponding evaluator entries inside `evaluators[]`.

  ## Migration

  ### YAML eval config files

  Before:
  ```yaml
  metrics:
    - tool_trajectory_avg_score
  judge_model: gemini-2.5-flash
  threshold: 0.8
  trajectory_match_type: EXACT
  custom_evaluators:
    - { name: my_eval, type: code, path: ./my_eval.py }
  ```

  After:
  ```yaml
  evaluators:
    - name: tool_trajectory_avg_score
      type: builtin
      judge_model: gemini-2.5-flash
      threshold: 0.8
      trajectory_match_type: EXACT
    - name: my_eval
      type: code
      path: ./my_eval.py
```

  ### `/api/evaluate`, `/api/evaluate/stream`, `/api/evaluate/json`, `/api/runs`

  Before:
  ```json
  { "metrics": ["tool_trajectory_avg_score"], "judgeModel": "gemini-2.5-flash" }
```

  After:
  ```json
  { "evaluators": [
      { "name": "tool_trajectory_avg_score", "type": "builtin",
        "judgeModel": "gemini-2.5-flash" }
    ]
  }
```

  Legacy keys now return 4xx with `Extra inputs are not permitted`.

  ### MCP `/api/streaming/evaluate-sessions`

  Same shape as `/api/evaluate` above. The old `metrics` / `judge_model`
  / `trajectory_match_type` top-level fields are rejected.

  ### CLI

  `agentevals list-metrics` has been removed. Use
  `agentevals evaluator list --source builtin` instead.
