### PR TITLE
Fix version bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -46,6 +48,8 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/publish-evaluator-sdk.yml
+++ b/.github/workflows/publish-evaluator-sdk.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@main
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/publish-evaluator-sdk.yml
+++ b/.github/workflows/publish-evaluator-sdk.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@main
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -30,9 +31,6 @@ jobs:
           node-version: '22'
           cache: npm
           cache-dependency-path: ui/package-lock.json
-
-      - name: Set version from tag
-        run: uv version "${{ github.event.inputs.tag || github.ref_name }}" --package agentevals-cli
 
       - name: Build core and bundled wheels
         run: make release
@@ -51,6 +49,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -65,11 +64,8 @@ jobs:
       # Same bundle as `make release` / `build-bundle`: wheel must include ui/dist in src/agentevals/_static
       # (see [tool.hatch.build] artifacts in pyproject.toml).
       - name: Release Python package (wheel + sdist with bundled UI)
-        env:
-          VERSION: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           uv sync --package agentevals-cli --all-extras
-          uv version "$VERSION" --package agentevals-cli
 
           make build-ui
           rm -rf src/agentevals/_static

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell grep '^version' pyproject.toml | cut -d'"' -f2)
+VERSION := $(shell uv run --with hatch hatch version 2>/dev/null)
 WHEEL := dist/agentevals_cli-$(VERSION)-py3-none-any.whl
 
 DOCKER_REGISTRY ?= soloio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "agentevals-cli"
-version = "0.7.1"
+dynamic = ["version"]
 description = "Standalone framework to evaluate agent correctness based on portable OpenTelemetry traces"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -39,6 +39,9 @@ postgres = [
 
 [project.scripts]
 agentevals = "agentevals.cli:main"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build]
 artifacts = ["src/agentevals/_static/**"]

--- a/src/agentevals/__init__.py
+++ b/src/agentevals/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("agentevals")
+    __version__ = version("agentevals-cli")
 except PackageNotFoundError:
     __version__ = "0.0.0-dev"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 import pytest
 from click.testing import CliRunner
 
+import agentevals
 from agentevals import cli
 from agentevals.runner import RunResult
 
@@ -163,3 +164,20 @@ def test_run_merges_explicit_metrics_with_config_file(monkeypatch, tmp_path):
         "custom_eval",
         "response_match_score",
     ]
+
+
+def test_version_resolves_from_installed_distribution():
+    assert agentevals.__version__ != "0.0.0-dev", (
+        "agentevals.__version__ fell back to the dev sentinel. Likely causes: "
+        "(1) the dist name in pyproject.toml diverged from the lookup string "
+        "in src/agentevals/__init__.py, or (2) hatch-vcs cannot resolve a "
+        "version (missing git tags in the build environment?)."
+    )
+
+
+def test_cli_version_flag_prints_real_version():
+    result = CliRunner().invoke(cli.main, ["--version"])
+
+    assert result.exit_code == 0, result.output
+    assert "0.0.0-dev" not in result.output, f"`agentevals --version` printed the dev sentinel: {result.output!r}"
+    assert agentevals.__version__ in result.output

--- a/ui/src/components/sidebar/Sidebar.tsx
+++ b/ui/src/components/sidebar/Sidebar.tsx
@@ -110,7 +110,7 @@ export const Sidebar: React.FC = () => {
             }}
           />
           {state.version && (
-            <span>v{state.version}</span>
+            <span style={{ fontSize: '0.5rem' }}>v{state.version}</span>
           )}
         </div>
       </nav>

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,6 @@ wheels = [
 
 [[package]]
 name = "agentevals-cli"
-version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -100,7 +99,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", marker = "extra == 'streaming'", specifier = ">=12.0" },
 ]
-provides-extras = ["live", "streaming", "openai", "postgres"]
+provides-extras = ["live", "openai", "postgres", "streaming"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What

`agentevals --version` has been printing `0.0.0-dev` on every published release since the PyPI rename to `agentevals-cli`. 

While in there:
- Switched to `hatch-vcs` so the version comes straight from git tags.
- Dropped the manual `uv version "$VERSION"` step in release.yml.
- CI checkouts got `fetch-depth: 0` so hatch-vcs can see tags.

Added 
 
- Two regression tests in `tests/test_cli.py` 
- Sidebar version span dropped to 0.5rem so long hatch-vcs dev versions like `v0.9.2.dev0+g<sha>` fit on a single line in the UI footer.

Fixes https://github.com/agentevals-dev/agentevals/issues/152