### PR TITLE
fix(streaming): normalize timestamps across common units

### DIFF
--- a/src/agentevals/streaming/incremental_processor.py
+++ b/src/agentevals/streaming/incremental_processor.py
@@ -36,14 +36,18 @@ logger = logging.getLogger(__name__)
 
 
 def _normalize_ts(raw_ts) -> float:
-    """Normalize a nanosecond timestamp (string or int) to seconds."""
+    """Normalize a contemporary Unix timestamp by inferring its unit from magnitude."""
     try:
-        ns = int(raw_ts)
+        timestamp = int(raw_ts)
     except (TypeError, ValueError):
         return 0.0
-    if ns > 1e15:
-        return ns / 1e9
-    return float(ns)
+    if timestamp >= 1e17:
+        return timestamp / 1e9
+    if timestamp >= 1e14:
+        return timestamp / 1e6
+    if timestamp >= 1e11:
+        return timestamp / 1e3
+    return float(timestamp)
 
 
 class IncrementalInvocationExtractor:

--- a/tests/test_incremental_processor.py
+++ b/tests/test_incremental_processor.py
@@ -1,0 +1,26 @@
+import pytest
+
+from agentevals.streaming.incremental_processor import _normalize_ts
+
+
+@pytest.mark.parametrize(
+    ("raw_ts", "expected"),
+    [
+        (1770000000, 1770000000.0),  # seconds
+        (1770000000000, 1770000000.0),  # milliseconds
+        (1770000000000000, 1770000000.0),  # microseconds
+        (1770000000000000000, 1770000000.0),  # nanoseconds
+    ],
+)
+def test_normalizes_timestamp_units(raw_ts, expected):
+    assert _normalize_ts(raw_ts) == expected
+
+
+def test_normalizes_numeric_string():
+    assert _normalize_ts("1770000000000000") == 1770000000.0
+
+
+@pytest.mark.parametrize("raw_ts", [None, "invalid"])
+def test_invalid_timestamp_returns_zero(raw_ts):
+    # Preserve the existing fallback for missing or malformed timestamps.
+    assert _normalize_ts(raw_ts) == 0.0


### PR DESCRIPTION
## Problem

The `_normalize_ts` function previously distinguished only between
nanosecond timestamps and timestamps that were assumed to already be
in seconds.

This caused microsecond timestamps to be treated as nanoseconds. For
example, `1770000000000000` microseconds was converted to `1770000.0`
seconds instead of `1770000000.0` seconds.

Millisecond timestamps had a similar problem because they were treated
as seconds without conversion.

## Changes

- Updated `_normalize_ts` to infer contemporary Unix timestamp units
  by magnitude.
- Added normalization for seconds, milliseconds, microseconds, and
  nanoseconds.
- Preserved the existing `0.0` fallback for missing or malformed
  timestamp values.
- Updated the function docstring to clarify that unit inference is
  intended for contemporary Unix timestamps.
- Added parameterized regression tests for all four supported units.
- Added tests for numeric string input, `None`, and malformed input.

## Testing

I ran the following checks:

- Ruff lint checks passed.
- Ruff format checks passed.
- The new timestamp tests passed: `7 passed`.
- Related log enrichment and OTLP receiver tests passed: `97 passed`.
- Full test suite result: `756 passed, 25 skipped, 3 failed`.

The three remaining failures are Windows symlink security tests that
require privileges to create symbolic links. The same three failures
were present before this change and are unrelated to timestamp
normalization.

## Related issue

This PR addresses the timestamp normalization item in #175. It does
not close #175 because that issue contains several independent cleanup
tasks.

## AI assistance

I used GPT 5.6Sol to help me understand the project architecture.