### PR TITLE
feat(ui): make Trace Editor tool calls editable

### DIFF
--- a/ui/src/components/builder/InvocationEditor.tsx
+++ b/ui/src/components/builder/InvocationEditor.tsx
@@ -1,11 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
 import { Input, Tag } from 'antd';
-import type { Invocation } from '../../lib/types';
+import type { Invocation, ToolCall, ToolResponse } from '../../lib/types';
 
 interface InvocationEditorProps {
   invocation: Invocation;
   onChange: (invocation: Invocation) => void;
+}
+
+interface JsonParseResult {
+  value: Record<string, unknown> | null;
+  error: string | null;
+}
+
+interface ToolCallEditorProps {
+  index: number;
+  toolUse: ToolCall;
+  toolResponse?: ToolResponse;
+  onIdentityChange: (index: number, updates: Partial<ToolCall>) => void;
+  onToolArgsChange: (index: number, args: Record<string, unknown>) => void;
+  onToolResponseChange: (index: number, response: Record<string, unknown>) => void;
 }
 
 export const InvocationEditor: React.FC<InvocationEditorProps> = ({
@@ -33,6 +47,55 @@ export const InvocationEditor: React.FC<InvocationEditorProps> = ({
       parts: [{ text }],
     };
     onChange(updated);
+  };
+
+  const updateIntermediateData = (nextToolUses: ToolCall[], nextToolResponses: ToolResponse[]) => {
+    const current = invocation.intermediateData || { toolUses: [], toolResponses: [] };
+    onChange({
+      ...invocation,
+      intermediateData: {
+        ...current,
+        toolUses: nextToolUses,
+        toolResponses: nextToolResponses,
+      },
+    });
+  };
+
+  const handleToolIdentityChange = (index: number, updates: Partial<ToolCall>) => {
+    const nextToolUses = [...toolUses];
+    const currentToolUse = nextToolUses[index];
+    if (!currentToolUse) return;
+
+    nextToolUses[index] = { ...currentToolUse, ...updates };
+
+    const nextToolResponses = [...toolResponses];
+    if (nextToolResponses[index]) {
+      nextToolResponses[index] = {
+        ...nextToolResponses[index],
+        ...(updates.name !== undefined ? { name: updates.name } : {}),
+        ...(updates.id !== undefined ? { id: updates.id } : {}),
+      };
+    }
+
+    updateIntermediateData(nextToolUses, nextToolResponses);
+  };
+
+  const handleToolArgsChange = (index: number, args: Record<string, unknown>) => {
+    const nextToolUses = [...toolUses];
+    const currentToolUse = nextToolUses[index];
+    if (!currentToolUse) return;
+
+    nextToolUses[index] = { ...currentToolUse, args };
+    updateIntermediateData(nextToolUses, [...toolResponses]);
+  };
+
+  const handleToolResponseChange = (index: number, response: Record<string, unknown>) => {
+    const nextToolResponses = [...toolResponses];
+    const currentToolResponse = nextToolResponses[index];
+    if (!currentToolResponse) return;
+
+    nextToolResponses[index] = { ...currentToolResponse, response };
+    updateIntermediateData([...toolUses], nextToolResponses);
   };
 
   return (
@@ -69,14 +132,123 @@ export const InvocationEditor: React.FC<InvocationEditorProps> = ({
             <Tag color="lime">Tool Trajectory</Tag>
             <span>{toolUses.length} tool call{toolUses.length !== 1 ? 's' : ''}</span>
           </div>
-          <div css={jsonDisplayStyle}>
-            <pre>{JSON.stringify({ toolUses, toolResponses }, null, 2)}</pre>
+          <div css={toolListStyle}>
+            {toolUses.map((toolUse, index) => (
+              <ToolCallEditor
+                key={`${toolUse.id || toolUse.name}-${index}`}
+                index={index}
+                toolUse={toolUse}
+                toolResponse={toolResponses[index]}
+                onIdentityChange={handleToolIdentityChange}
+                onToolArgsChange={handleToolArgsChange}
+                onToolResponseChange={handleToolResponseChange}
+              />
+            ))}
           </div>
         </div>
       )}
     </div>
   );
 };
+
+const ToolCallEditor: React.FC<ToolCallEditorProps> = ({
+  index,
+  toolUse,
+  toolResponse,
+  onIdentityChange,
+  onToolArgsChange,
+  onToolResponseChange,
+}) => {
+  const [argsText, setArgsText] = useState(formatJsonObject(toolUse.args));
+  const [responseText, setResponseText] = useState(formatJsonObject(toolResponse?.response));
+  const [argsError, setArgsError] = useState<string | null>(null);
+  const [responseError, setResponseError] = useState<string | null>(null);
+
+  const handleArgsTextChange = (text: string) => {
+    setArgsText(text);
+    const parsed = parseJsonObject(text);
+    setArgsError(parsed.error);
+    if (parsed.value) {
+      onToolArgsChange(index, parsed.value);
+    }
+  };
+
+  const handleResponseTextChange = (text: string) => {
+    setResponseText(text);
+    const parsed = parseJsonObject(text);
+    setResponseError(parsed.error);
+    if (parsed.value) {
+      onToolResponseChange(index, parsed.value);
+    }
+  };
+
+  return (
+    <div css={toolEditorStyle}>
+      <div css={toolHeaderStyle}>
+        <Tag color="green">Tool Call {index + 1}</Tag>
+      </div>
+
+      <div css={identityGridStyle}>
+        <label css={fieldLabelStyle}>
+          <span>Tool Name</span>
+          <Input
+            value={toolUse.name}
+            onChange={(e) => onIdentityChange(index, { name: e.target.value })}
+            placeholder="Tool name"
+          />
+        </label>
+        <label css={fieldLabelStyle}>
+          <span>Call ID</span>
+          <Input
+            value={toolUse.id || ''}
+            onChange={(e) => onIdentityChange(index, { id: e.target.value || undefined })}
+            placeholder="Optional call ID"
+          />
+        </label>
+      </div>
+
+      <label css={fieldLabelStyle}>
+        <span>Arguments</span>
+        <Input.TextArea
+          value={argsText}
+          onChange={(e) => handleArgsTextChange(e.target.value)}
+          rows={4}
+          status={argsError ? 'error' : undefined}
+        />
+      </label>
+      {argsError && <div css={validationTextStyle}>{argsError}</div>}
+
+      {toolResponse && (
+        <label css={fieldLabelStyle}>
+          <span>Response</span>
+          <Input.TextArea
+            value={responseText}
+            onChange={(e) => handleResponseTextChange(e.target.value)}
+            rows={4}
+            status={responseError ? 'error' : undefined}
+          />
+        </label>
+      )}
+      {responseError && <div css={validationTextStyle}>{responseError}</div>}
+    </div>
+  );
+};
+
+function formatJsonObject(value: Record<string, unknown> | undefined): string {
+  return JSON.stringify(value || {}, null, 2);
+}
+
+function parseJsonObject(text: string): JsonParseResult {
+  try {
+    const parsed = JSON.parse(text.trim() || '{}');
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { value: null, error: 'Enter a JSON object.' };
+    }
+    return { value: parsed, error: null };
+  } catch {
+    return { value: null, error: 'Enter valid JSON.' };
+  }
+}
 
 const containerStyle = css`
   background: var(--bg-primary);
@@ -107,17 +279,48 @@ const labelStyle = css`
   color: var(--text-secondary);
 `;
 
-const jsonDisplayStyle = css`
+const toolListStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const toolEditorStyle = css`
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: 4px;
-  padding: 8px;
+  padding: 12px;
+`;
 
-  pre {
-    margin: 0;
-    font-size: 0.75rem;
-    font-family: monospace;
-    color: var(--text-secondary);
-    overflow-x: auto;
+const toolHeaderStyle = css`
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+`;
+
+const identityGridStyle = css`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+  margin-bottom: 12px;
+`;
+
+const fieldLabelStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+
+  &:last-child {
+    margin-bottom: 0;
   }
+`;
+
+const validationTextStyle = css`
+  margin-top: -6px;
+  margin-bottom: 12px;
+  font-size: 0.75rem;
+  color: var(--status-failure);
 `;

--- a/ui/src/components/upload/TraceEditorDrawer.tsx
+++ b/ui/src/components/upload/TraceEditorDrawer.tsx
@@ -45,7 +45,7 @@ export const TraceEditorDrawer: React.FC<TraceEditorDrawerProps> = ({ file, file
         setParsedFile(parsed);
 
         const traces = await loadTraces(content);
-        const mappings = buildEditMappings(traces, parsed);
+        const mappings = buildEditMappings(traces);
         setEditMappings(mappings);
       }),
       convertTraces([file]).then((response) => {

--- a/ui/src/lib/trace-patcher.ts
+++ b/ui/src/lib/trace-patcher.ts
@@ -1,4 +1,14 @@
-import type { Trace, Span, Invocation, ParsedTraceFile, SpanEditMapping, SpanLocationRef } from './types';
+import type {
+  Trace,
+  Span,
+  Invocation,
+  ParsedTraceFile,
+  SpanEditMapping,
+  SpanLocationRef,
+  ToolCall,
+  ToolMessageEditLocation,
+  ToolResponse,
+} from './types';
 import {
   ADK_SCOPE,
   detectTraceFormat,
@@ -7,6 +17,13 @@ import {
   USER_ROLES,
   ASSISTANT_ROLES,
 } from './trace-helpers';
+
+const ADK_TOOL_CALL_ARGS_ATTR = 'gcp.vertex.agent.tool_call_args';
+const ADK_TOOL_RESPONSE_ATTR = 'gcp.vertex.agent.tool_response';
+const OTEL_TOOL_NAME_ATTR = 'gen_ai.tool.name';
+const OTEL_TOOL_CALL_ID_ATTR = 'gen_ai.tool.call.id';
+const OTEL_TOOL_CALL_ARGS_ATTR = 'gen_ai.tool.call.arguments';
+const OTEL_TOOL_CALL_RESULT_ATTR = 'gen_ai.tool.call.result';
 
 export function parseTraceFileForEditing(content: string, fileName: string): ParsedTraceFile {
   const trimmed = content.trim();
@@ -62,7 +79,7 @@ function parseJaegerJson(content: string, fileName: string): ParsedTraceFile {
   return { format: 'jaeger', fileName, rawData, spanIndex };
 }
 
-export function buildEditMappings(traces: Trace[], _parsedFile: ParsedTraceFile): SpanEditMapping[] {
+export function buildEditMappings(traces: Trace[]): SpanEditMapping[] {
   const mappings: SpanEditMapping[] = [];
 
   for (const trace of traces) {
@@ -130,12 +147,20 @@ function buildGenAIMappings(trace: Trace): SpanEditMapping[] {
 
     if (!userInputAttrKey || !finalResponseAttrKey) continue;
 
+    const toolMessageLocations = llmSpans
+      .map((span): ToolMessageEditLocation | null => {
+        const attrKey = resolveOutputAttrKey(span);
+        return attrKey ? { spanId: span.spanId, attrKey } : null;
+      })
+      .filter((location): location is ToolMessageEditLocation => location !== null);
+
     mappings.push({
       invocationId: rootSpan.spanId,
       format: 'genai',
       userInputSpanId: firstLlm.spanId,
       finalResponseSpanId: lastLlm.spanId,
       toolSpanIds: [],
+      toolMessageLocations,
       userInputAttrKey,
       finalResponseAttrKey,
     });
@@ -178,9 +203,261 @@ export function applyEditsAndSerialize(
     if (responseText !== undefined) {
       patchAttribute(parsedFile, mapping.finalResponseSpanId, mapping.finalResponseAttrKey, mapping.format, 'response', responseText);
     }
+
+    const toolUses = inv.intermediateData?.toolUses || [];
+    const toolResponses = inv.intermediateData?.toolResponses || [];
+    if (toolUses.length > 0 || toolResponses.length > 0) {
+      patchToolTrajectory(parsedFile, mapping, toolUses, toolResponses);
+    }
   }
 
   return serialize(parsedFile);
+}
+
+function patchToolTrajectory(
+  parsedFile: ParsedTraceFile,
+  mapping: SpanEditMapping,
+  toolUses: ToolCall[],
+  toolResponses: ToolResponse[]
+): void {
+  mapping.toolSpanIds.forEach((spanId, index) => {
+    const toolUse = toolUses[index];
+    if (!toolUse) return;
+
+    const rawSpan = getRawSpan(parsedFile, spanId);
+    if (!rawSpan) return;
+
+    patchRawToolSpan(rawSpan, parsedFile.format, toolUse, toolResponses[index]);
+  });
+
+  if (mapping.toolMessageLocations && toolUses.length > 0) {
+    patchToolMessageLocations(parsedFile, mapping.toolMessageLocations, toolUses);
+  }
+}
+
+function getRawSpan(parsedFile: ParsedTraceFile, spanId: string): any | null {
+  const locRef = parsedFile.spanIndex.get(spanId);
+  if (!locRef) return null;
+
+  if (parsedFile.format === 'otlp-jsonl') {
+    return parsedFile.rawData[locRef.lineIndex!];
+  }
+
+  return parsedFile.rawData.data?.[locRef.traceIndex!]?.spans?.[locRef.spanIndex!] || null;
+}
+
+function patchRawToolSpan(
+  rawSpan: any,
+  format: ParsedTraceFile['format'],
+  toolUse: ToolCall,
+  toolResponse?: ToolResponse
+): void {
+  patchRawToolOperationName(rawSpan, toolUse.name);
+  setRawStringAttribute(rawSpan, format, ADK_TOOL_CALL_ARGS_ATTR, JSON.stringify(toolUse.args || {}), true);
+
+  if (hasRawStringAttribute(rawSpan, format, OTEL_TOOL_NAME_ATTR)) {
+    setRawStringAttribute(rawSpan, format, OTEL_TOOL_NAME_ATTR, toolUse.name, false);
+  }
+  if (hasRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_ARGS_ATTR)) {
+    setRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_ARGS_ATTR, JSON.stringify(toolUse.args || {}), false);
+  }
+
+  if (toolUse.id !== undefined || hasRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_ID_ATTR)) {
+    setRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_ID_ATTR, toolUse.id || '', toolUse.id !== undefined);
+  }
+
+  if (toolResponse) {
+    setRawStringAttribute(rawSpan, format, ADK_TOOL_RESPONSE_ATTR, JSON.stringify(toolResponse.response || {}), true);
+
+    if (hasRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_RESULT_ATTR)) {
+      setRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_RESULT_ATTR, JSON.stringify(toolResponse.response || {}), false);
+    }
+  }
+}
+
+function patchRawToolOperationName(rawSpan: any, toolName: string): void {
+  const nextOperationName = `execute_tool ${toolName}`;
+
+  if (typeof rawSpan.operationName === 'string' && rawSpan.operationName.startsWith('execute_tool')) {
+    rawSpan.operationName = nextOperationName;
+  }
+  if (typeof rawSpan.name === 'string' && rawSpan.name.startsWith('execute_tool')) {
+    rawSpan.name = nextOperationName;
+  }
+}
+
+function hasRawStringAttribute(rawSpan: any, format: ParsedTraceFile['format'], attrKey: string): boolean {
+  const attrs = format === 'otlp-jsonl' ? rawSpan.attributes : rawSpan.tags;
+  return Array.isArray(attrs) && attrs.some((attr: any) => attr.key === attrKey);
+}
+
+function readRawStringAttribute(rawSpan: any, format: ParsedTraceFile['format'], attrKey: string): string | null {
+  const attrs = format === 'otlp-jsonl' ? rawSpan.attributes : rawSpan.tags;
+  if (!Array.isArray(attrs)) return null;
+
+  const attr = attrs.find((candidate: any) => candidate.key === attrKey);
+  if (!attr) return null;
+
+  if (format === 'otlp-jsonl') {
+    return typeof attr.value?.stringValue === 'string' ? attr.value.stringValue : null;
+  }
+  return typeof attr.value === 'string' ? attr.value : null;
+}
+
+function setRawStringAttribute(
+  rawSpan: any,
+  format: ParsedTraceFile['format'],
+  attrKey: string,
+  value: string,
+  createIfMissing: boolean
+): void {
+  const containerKey = format === 'otlp-jsonl' ? 'attributes' : 'tags';
+  if (!Array.isArray(rawSpan[containerKey])) {
+    if (!createIfMissing) return;
+    rawSpan[containerKey] = [];
+  }
+
+  const attrs = rawSpan[containerKey];
+  const attr = attrs.find((candidate: any) => candidate.key === attrKey);
+  if (attr) {
+    if (format === 'otlp-jsonl') {
+      attr.value = { stringValue: value };
+    } else {
+      attr.type = 'string';
+      attr.value = value;
+    }
+    return;
+  }
+
+  if (!createIfMissing) return;
+
+  if (format === 'otlp-jsonl') {
+    attrs.push({ key: attrKey, value: { stringValue: value } });
+  } else {
+    attrs.push({ key: attrKey, type: 'string', value });
+  }
+}
+
+function patchToolMessageLocations(
+  parsedFile: ParsedTraceFile,
+  locations: ToolMessageEditLocation[],
+  toolUses: ToolCall[]
+): void {
+  for (const location of locations) {
+    const rawSpan = getRawSpan(parsedFile, location.spanId);
+    if (!rawSpan) continue;
+
+    const current = readRawStringAttribute(rawSpan, parsedFile.format, location.attrKey);
+    if (!current) continue;
+
+    try {
+      const data = JSON.parse(current);
+      const changed = patchGenAIToolMessages(data, toolUses);
+      if (changed) {
+        setRawStringAttribute(rawSpan, parsedFile.format, location.attrKey, JSON.stringify(data), false);
+      }
+    } catch {
+      continue;
+    }
+  }
+}
+
+function patchGenAIToolMessages(messages: any, toolUses: ToolCall[]): boolean {
+  if (!Array.isArray(messages)) return false;
+
+  const toolsById = new Map(
+    toolUses
+      .filter((toolUse) => toolUse.id)
+      .map((toolUse) => [toolUse.id, toolUse])
+  );
+  let nextToolIndex = 0;
+  let changed = false;
+
+  const nextTool = (toolCallId: unknown): ToolCall | null => {
+    if (typeof toolCallId === 'string') {
+      const byId = toolsById.get(toolCallId);
+      if (byId) return byId;
+    }
+
+    const toolUse = toolUses[nextToolIndex];
+    nextToolIndex += 1;
+    return toolUse || null;
+  };
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== 'object') continue;
+    if (msg.role && !ASSISTANT_ROLES.includes(msg.role)) continue;
+
+    if (Array.isArray(msg.tool_calls)) {
+      for (const toolCall of msg.tool_calls) {
+        const toolUse = nextTool(toolCall?.id);
+        if (toolUse && patchOpenAIToolCall(toolCall, toolUse)) {
+          changed = true;
+        }
+      }
+    }
+
+    if (Array.isArray(msg.parts)) {
+      for (const part of msg.parts) {
+        if (!part || typeof part !== 'object' || part.type !== 'tool_call') continue;
+
+        const toolUse = nextTool(part.id);
+        if (toolUse && patchGenAIToolPart(part, toolUse)) {
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return changed;
+}
+
+function patchOpenAIToolCall(toolCall: any, toolUse: ToolCall): boolean {
+  if (!toolCall || typeof toolCall !== 'object') return false;
+
+  let changed = false;
+  if (toolUse.id !== undefined && toolCall.id !== toolUse.id) {
+    toolCall.id = toolUse.id;
+    changed = true;
+  }
+
+  const fn = toolCall.function;
+  if (fn && typeof fn === 'object') {
+    if (fn.name !== toolUse.name) {
+      fn.name = toolUse.name;
+      changed = true;
+    }
+    const nextArgs = JSON.stringify(toolUse.args || {});
+    if (fn.arguments !== nextArgs) {
+      fn.arguments = nextArgs;
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+function patchGenAIToolPart(part: any, toolUse: ToolCall): boolean {
+  let changed = false;
+
+  if (toolUse.id !== undefined && part.id !== toolUse.id) {
+    part.id = toolUse.id;
+    changed = true;
+  }
+  if (part.name !== toolUse.name) {
+    part.name = toolUse.name;
+    changed = true;
+  }
+
+  const nextArgs = typeof part.arguments === 'string'
+    ? JSON.stringify(toolUse.args || {})
+    : toolUse.args || {};
+  if (JSON.stringify(part.arguments) !== JSON.stringify(nextArgs)) {
+    part.arguments = nextArgs;
+    changed = true;
+  }
+
+  return changed;
 }
 
 function patchAttribute(

--- a/ui/src/lib/trace-patcher.ts
+++ b/ui/src/lib/trace-patcher.ts
@@ -153,13 +153,14 @@ function buildGenAIMappings(trace: Trace): SpanEditMapping[] {
         return attrKey ? { spanId: span.spanId, attrKey } : null;
       })
       .filter((location): location is ToolMessageEditLocation => location !== null);
+    const toolSpans = findGenAIToolSpans(rootSpan);
 
     mappings.push({
       invocationId: rootSpan.spanId,
       format: 'genai',
       userInputSpanId: firstLlm.spanId,
       finalResponseSpanId: lastLlm.spanId,
-      toolSpanIds: [],
+      toolSpanIds: toolSpans.map(s => s.spanId),
       toolMessageLocations,
       userInputAttrKey,
       finalResponseAttrKey,
@@ -183,6 +184,27 @@ function resolveOutputAttrKey(span: Span): string | null {
   return null;
 }
 
+function findGenAIToolSpans(root: Span): Span[] {
+  const results: Span[] = [];
+  const queue = [...root.children];
+
+  while (queue.length > 0) {
+    const span = queue.shift()!;
+    if (
+      span.operationName.startsWith('execute_tool') ||
+      span.tags[OTEL_TOOL_NAME_ATTR] ||
+      span.tags[OTEL_TOOL_CALL_ARGS_ATTR] ||
+      span.tags[OTEL_TOOL_CALL_RESULT_ATTR]
+    ) {
+      results.push(span);
+    }
+    queue.push(...span.children);
+  }
+
+  results.sort((a, b) => a.startTime - b.startTime);
+  return results;
+}
+
 export function applyEditsAndSerialize(
   parsedFile: ParsedTraceFile,
   invocations: Invocation[],
@@ -191,7 +213,7 @@ export function applyEditsAndSerialize(
   const mappingByInvId = new Map(editMappings.map(m => [m.invocationId, m]));
 
   for (const inv of invocations) {
-    const mapping = mappingByInvId.get(inv.invocationId);
+    const mapping = findMappingForInvocation(inv.invocationId, mappingByInvId);
     if (!mapping) continue;
 
     const userText = inv.userContent?.parts?.[0]?.text;
@@ -214,6 +236,20 @@ export function applyEditsAndSerialize(
   return serialize(parsedFile);
 }
 
+function findMappingForInvocation(
+  invocationId: string,
+  mappingByInvId: Map<string, SpanEditMapping>
+): SpanEditMapping | undefined {
+  const direct = mappingByInvId.get(invocationId);
+  if (direct) return direct;
+
+  if (invocationId.startsWith('genai-')) {
+    return mappingByInvId.get(invocationId.slice('genai-'.length));
+  }
+
+  return undefined;
+}
+
 function patchToolTrajectory(
   parsedFile: ParsedTraceFile,
   mapping: SpanEditMapping,
@@ -227,7 +263,7 @@ function patchToolTrajectory(
     const rawSpan = getRawSpan(parsedFile, spanId);
     if (!rawSpan) return;
 
-    patchRawToolSpan(rawSpan, parsedFile.format, toolUse, toolResponses[index]);
+    patchRawToolSpan(rawSpan, parsedFile.format, mapping.format, toolUse, toolResponses[index]);
   });
 
   if (mapping.toolMessageLocations && toolUses.length > 0) {
@@ -248,29 +284,35 @@ function getRawSpan(parsedFile: ParsedTraceFile, spanId: string): any | null {
 
 function patchRawToolSpan(
   rawSpan: any,
-  format: ParsedTraceFile['format'],
+  rawFormat: ParsedTraceFile['format'],
+  traceFormat: SpanEditMapping['format'],
   toolUse: ToolCall,
   toolResponse?: ToolResponse
 ): void {
   patchRawToolOperationName(rawSpan, toolUse.name);
-  setRawStringAttribute(rawSpan, format, ADK_TOOL_CALL_ARGS_ATTR, JSON.stringify(toolUse.args || {}), true);
 
-  if (hasRawStringAttribute(rawSpan, format, OTEL_TOOL_NAME_ATTR)) {
-    setRawStringAttribute(rawSpan, format, OTEL_TOOL_NAME_ATTR, toolUse.name, false);
-  }
-  if (hasRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_ARGS_ATTR)) {
-    setRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_ARGS_ATTR, JSON.stringify(toolUse.args || {}), false);
+  if (traceFormat === 'adk' || hasRawStringAttribute(rawSpan, rawFormat, ADK_TOOL_CALL_ARGS_ATTR)) {
+    setRawStringAttribute(rawSpan, rawFormat, ADK_TOOL_CALL_ARGS_ATTR, JSON.stringify(toolUse.args || {}), traceFormat === 'adk');
   }
 
-  if (toolUse.id !== undefined || hasRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_ID_ATTR)) {
-    setRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_ID_ATTR, toolUse.id || '', toolUse.id !== undefined);
+  if (hasRawStringAttribute(rawSpan, rawFormat, OTEL_TOOL_NAME_ATTR)) {
+    setRawStringAttribute(rawSpan, rawFormat, OTEL_TOOL_NAME_ATTR, toolUse.name, false);
+  }
+  if (hasRawStringAttribute(rawSpan, rawFormat, OTEL_TOOL_CALL_ARGS_ATTR)) {
+    setRawStringAttribute(rawSpan, rawFormat, OTEL_TOOL_CALL_ARGS_ATTR, JSON.stringify(toolUse.args || {}), false);
+  }
+
+  if (toolUse.id !== undefined || hasRawStringAttribute(rawSpan, rawFormat, OTEL_TOOL_CALL_ID_ATTR)) {
+    setRawStringAttribute(rawSpan, rawFormat, OTEL_TOOL_CALL_ID_ATTR, toolUse.id || '', toolUse.id !== undefined);
   }
 
   if (toolResponse) {
-    setRawStringAttribute(rawSpan, format, ADK_TOOL_RESPONSE_ATTR, JSON.stringify(toolResponse.response || {}), true);
+    if (traceFormat === 'adk' || hasRawStringAttribute(rawSpan, rawFormat, ADK_TOOL_RESPONSE_ATTR)) {
+      setRawStringAttribute(rawSpan, rawFormat, ADK_TOOL_RESPONSE_ATTR, JSON.stringify(toolResponse.response || {}), traceFormat === 'adk');
+    }
 
-    if (hasRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_RESULT_ATTR)) {
-      setRawStringAttribute(rawSpan, format, OTEL_TOOL_CALL_RESULT_ATTR, JSON.stringify(toolResponse.response || {}), false);
+    if (hasRawStringAttribute(rawSpan, rawFormat, OTEL_TOOL_CALL_RESULT_ATTR)) {
+      setRawStringAttribute(rawSpan, rawFormat, OTEL_TOOL_CALL_RESULT_ATTR, JSON.stringify(toolResponse.response || {}), false);
     }
   }
 }
@@ -374,14 +416,15 @@ function patchGenAIToolMessages(messages: any, toolUses: ToolCall[]): boolean {
   let changed = false;
 
   const nextTool = (toolCallId: unknown): ToolCall | null => {
+    const positionalToolUse = toolUses[nextToolIndex];
+    nextToolIndex += 1;
+
     if (typeof toolCallId === 'string') {
       const byId = toolsById.get(toolCallId);
       if (byId) return byId;
     }
 
-    const toolUse = toolUses[nextToolIndex];
-    nextToolIndex += 1;
-    return toolUse || null;
+    return positionalToolUse || null;
   };
 
   for (const msg of messages) {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -524,6 +524,11 @@ export interface InspectorUIState {
 // Trace editor types
 export type TraceFileFormat = 'jaeger' | 'otlp-jsonl';
 
+export interface ToolMessageEditLocation {
+  spanId: string;
+  attrKey: string;
+}
+
 export interface SpanLocationRef {
   traceIndex?: number;
   spanIndex?: number;
@@ -543,6 +548,7 @@ export interface SpanEditMapping {
   userInputSpanId: string;
   finalResponseSpanId: string;
   toolSpanIds: string[];
+  toolMessageLocations?: ToolMessageEditLocation[];
   userInputAttrKey: string;
   finalResponseAttrKey: string;
 }


### PR DESCRIPTION
This PR addresses #121 by making tool call data editable in the trace editor instead of showing it only as read-only JSON.
What changed:
- Tool call name, call ID, arguments, and response data can now be edited from the invocation editor
- Tool argument and response editors validate that the entered value is a JSON object before applying changes 
- Edited ADK tool calls are serialized back into the original trace span
- GenAI output-message tool call mappings are tracked so embedded tool call data can be patched where available

Testing:
- npm run build
- npx eslint src/components/builder/InvocationEditor.tsx
- uv run pytest -- 759 passed, 25 skipped
- git diff -- check

Disclosure: This PR was prepared with non-trivial AI assistance under my direction and review. 
I am Dorothy, the creator of SCARAB. 

