### PR TITLE
ci: run tests with all extras and gate the lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Verify uv.lock matches pyproject.toml
+        run: uv lock --check
+
       - name: Install dependencies
         run: |
           uv venv
@@ -62,7 +65,7 @@ jobs:
         run: |
           uv venv --python ${{ matrix.python-version }}
           uv pip install setuptools
-          uv sync --dev --python ${{ matrix.python-version }}
+          uv sync --dev --all-extras --frozen --python ${{ matrix.python-version }}
 
       - name: Run tests
         run: uv run pytest -m "not integration and not e2e" --tb=short -q

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -400,5 +400,7 @@ async def test_evaluate_sessions_posts_builtin_evaluator_overrides(monkeypatch):
             "threshold": 0.9,
             "judgeModel": "gemini-2.5-flash",
             "trajectoryMatchType": "IN_ORDER",
+            "credentialRef": None,
+            "judgeBaseUrl": None,
         }
     ]


### PR DESCRIPTION
CI installed no optional extras, so the 20 tests in `test_mcp_server.py` were skipped on every run, and a stale assertion in one of them went unnoticed. CI also never checked that `uv.lock` matches `pyproject.toml`.

  * test job now syncs `--all-extras --frozen`
  * lint job now runs `uv lock --check`
  * fixes the stale assertion this uncovered

Verified 751 passed, 6 skipped on Python 3.11 against a real all-extras environment, and the same on 3.14.
