### PR TITLE
chore(ci): group dependabot updates and pin actions to SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "CI"
+    open-pull-requests-limit: 2
+    labels: ["dependencies", "CI"]
     commit-message:
       prefix: "chore(deps):"
     cooldown:
@@ -17,25 +15,18 @@ updates:
     groups:
       github-actions:
         applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+        patterns: ["*"]
       github-actions-security:
         applies-to: security-updates
-        patterns:
-          - "*"
+        patterns: ["*"]
 
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "CLI"
+    open-pull-requests-limit: 3
+    labels: ["dependencies", "CLI"]
     commit-message:
       prefix: "chore(deps):"
       prefix-development: "chore(deps-dev):"
@@ -49,91 +40,57 @@ updates:
           - "google-adk"
           - "google-genai"
           - "google-auth*"
-        update-types:
-          - "minor"
-          - "patch"
-      python-development:
+      python:
         applies-to: version-updates
-        dependency-type: "development"
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-      python-minor-patch:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+        patterns: ["*"]
       python-security:
         applies-to: security-updates
-        patterns:
-          - "*"
+        patterns: ["*"]
 
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "UI"
+    open-pull-requests-limit: 2
+    labels: ["dependencies", "UI"]
     commit-message:
       prefix: "chore(deps):"
       prefix-development: "chore(deps-dev):"
     cooldown:
       default-days: 5
+      semver-major-days: 14
     ignore:
-      # react/vite/antd majors require migrations.
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
+      # Majors need a migration pass; bump these by hand.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "antd"
+        update-types: ["version-update:semver-major"]
     groups:
-      npm-dev-tooling:
+      npm:
         applies-to: version-updates
-        dependency-type: "development"
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-      npm-runtime:
-        applies-to: version-updates
-        dependency-type: "production"
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+        patterns: ["*"]
       npm-security:
         applies-to: security-updates
-        patterns:
-          - "*"
+        patterns: ["*"]
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
+    open-pull-requests-limit: 1
+    labels: ["dependencies"]
     commit-message:
       prefix: "chore(deps):"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
     cooldown:
       default-days: 5
+      semver-major-days: 14
     groups:
       docker-base-images:
         applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   helm-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Lint + template
         run: make helm-test
@@ -21,11 +21,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -50,11 +50,11 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 

--- a/.github/workflows/publish-evaluator-sdk.yml
+++ b/.github/workflows/publish-evaluator-sdk.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       # Repo root cwd: uv build puts artifacts in ./dist; uv publish looks for dist/* relative to cwd.
       - name: 'Release Python Packages'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
           cache: npm
@@ -35,7 +35,7 @@ jobs:
       - name: Build core and bundled wheels
         run: make release
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels
           path: |
@@ -46,16 +46,16 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
           cache: npm
@@ -82,12 +82,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wheels
           path: dist/
 
-      - uses: softprops/action-gh-release@v2.5.0
+      - uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: dist/**/*.whl
@@ -100,22 +100,22 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build and push
         run: |
@@ -134,12 +134,12 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
Dependabot opened 7 PRs on its first run with warnings. This PR fixes 2 things:

 - The version update groups had `update-types: [minor, patch]` on them, which does not mean "handle majors elsewhere", it means majors fall out of the group and each gets its own PR. That accounts for 3 of the 7. Dropped those filters, merged uv 3 groups into 2 and npm 2 into 1, and narrowed the npm major ignore from `"*"` (which silenced everything in ui/, not just react/vite/antd) to the 4 packages that actually need a migration. Should be 2 or 3 grouped PRs a week now instead of 7 to 10.

 -  All 10 actions were on mutable tags. Pinned every one to a commit SHA with the version in a trailing comment, same as we do elsewhere. Tags can be repointed, and in release.yml that reaches PYPI_TOKEN, GHCR packages:write, and contents:write. Dependabot bumps SHA pins and rewrites the comment automatically, so no extra upkeep.

Also fixes setup-uv being on v6 in publish-evaluator-sdk.yml while everything else was on v7.

Base images in the Dockerfile stay on tags on purpose. We want rolling OS security patches there; the SHA pinning is about not executing code from a mutable ref.

Closes #189, #190, #191, #192, #193, #194, #195