### PR TITLE
fix(ci): drop unsupported semver-major-days from docker cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,7 +89,6 @@ updates:
       prefix: "chore(deps):"
     cooldown:
       default-days: 5
-      semver-major-days: 14
     groups:
       docker-base-images:
         applies-to: version-updates


### PR DESCRIPTION
Dependabot rejected the config I merged in the last PR:
```
The property '#/updates/3/cooldown/semver-major-days' is not supported for the package ecosystem 'docker'
```

Now Docker keeps `default-days: 5`, and uv and npm keep theirs since those validated fine.