### PR TITLE
Migrate base image to `chainguard` + python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN npm run build
 
 FROM ${BASE_IMAGE_REGISTRY}/chainguard/wolfi-base:latest
 
-ARG TOOLS_PYTHON_VERSION=3.14
+ARG PYTHON_VERSION=3.14
 # Shared libraries the compiled wheels in the venv link against (scikit-learn and
 # tokenizers need libstdc++); tzdata backs zoneinfo lookups.
-RUN apk add --no-cache python-${TOOLS_PYTHON_VERSION} ca-certificates libstdc++ \
+RUN apk add --no-cache python-${PYTHON_VERSION} ca-certificates libstdc++ \
         zlib libffi sqlite-libs bzip2 xz tzdata
 
 WORKDIR /app
@@ -42,15 +42,8 @@ COPY --from=ui /build/ui/dist ./src/agentevals/_static
 ARG VERSION
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
-ENV UV_PYTHON_PREFERENCE=only-system
-
-RUN uv sync --frozen --no-dev --extra live --extra postgres --extra kubernetes \
-    # The runtime only uses the uv-managed venv; drop the base image's bundled
-    # pip so its vendored packages (msgpack, pkg_resources) don't ship unused.
-    && rm -rf /usr/lib/python*/site-packages/pip \
-              /usr/lib/python*/site-packages/pip-*.dist-info \
-              /usr/bin/pip* \
-    && ! python3 -c "import pip" 2>/dev/null \
+RUN UV_PYTHON_PREFERENCE=only-system \
+    uv sync --frozen --no-dev --extra live --extra postgres --extra kubernetes \
     && addgroup -g 1000 app \
     && adduser -u 1000 -G app -h /app -D -H app \
     && chown -R app:app /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 # syntax=docker/dockerfile:1
 
+ARG BASE_IMAGE_REGISTRY=cgr.dev
+ARG UV_VERSION=0.12.11
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-bin
+
 FROM node:26-bookworm-slim AS ui
 WORKDIR /build/ui
 COPY ui/package.json ui/package-lock.json ./
@@ -10,13 +15,19 @@ RUN npm rebuild esbuild
 COPY ui/ ./
 RUN npm run build
 
-FROM python:3.14-slim-bookworm
+FROM ${BASE_IMAGE_REGISTRY}/chainguard/wolfi-base:latest
+
+ARG TOOLS_PYTHON_VERSION=3.14
+# Shared libraries the compiled wheels in the venv link against (scikit-learn and
+# tokenizers need libstdc++); tzdata backs zoneinfo lookups.
+RUN apk add --no-cache python-${TOOLS_PYTHON_VERSION} ca-certificates libstdc++ \
+        zlib libffi sqlite-libs bzip2 xz tzdata
 
 WORKDIR /app
 
 # Install uv binary only (no pip); same approach as astral-sh/uv's Dockerfile.
 # https://github.com/astral-sh/uv/blob/6d889fd53d5c108d304c5a4085eb3140ec6a9cdb/Dockerfile#L21
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=uv-bin /uv /usr/local/bin/uv
 
 COPY pyproject.toml uv.lock README.md ./
 COPY packages ./packages
@@ -31,15 +42,17 @@ COPY --from=ui /build/ui/dist ./src/agentevals/_static
 ARG VERSION
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
+ENV UV_PYTHON_PREFERENCE=only-system
+
 RUN uv sync --frozen --no-dev --extra live --extra postgres --extra kubernetes \
     # The runtime only uses the uv-managed venv; drop the base image's bundled
     # pip so its vendored packages (msgpack, pkg_resources) don't ship unused.
-    && rm -rf /usr/local/lib/python*/site-packages/pip \
-              /usr/local/lib/python*/site-packages/pip-*.dist-info \
-              /usr/local/bin/pip* \
-    && ! /usr/local/bin/python -c "import pip" 2>/dev/null \
-    && groupadd --gid 1000 app \
-    && useradd --uid 1000 --gid app --home-dir /app --no-log-init app \
+    && rm -rf /usr/lib/python*/site-packages/pip \
+              /usr/lib/python*/site-packages/pip-*.dist-info \
+              /usr/bin/pip* \
+    && ! python3 -c "import pip" 2>/dev/null \
+    && addgroup -g 1000 app \
+    && adduser -u 1000 -G app -h /app -D -H app \
     && chown -R app:app /app
 
 USER app


### PR DESCRIPTION
# Context

Migrating from the bookworm base image to a `chainguard/wolfi` base for reduce CVE impact.

We shouldn't directly use `chainguard/python`, because it would only support `latest` pinning for free-tier consumers. This means it could upgrade minor versions under our feet, causing issues. The alternative approach [as documented in chainguard docs](https://www.chainguard.dev/unchained/a-guide-on-how-to-use-chainguard-images-for-public-catalog-tier-users) is to use a `wolfi-base` with an `apk add` for languages needed.

## CVE Findings

Measured with `trivy 0.70.0`, `--scanners vuln`, all package types, `arm64` (since that's what I biult natively).

High+: 61 → 1.

- before: 5 CRITICAL + 56 HIGH
- after: 0 CRITICAL + 1 HIGH

The 5 critical CVEs were all stemming from the Debian base: CVE-2023-45853, CVE-2025-7458, CVE-2026-13221, CVE-2026-42496, CVE-2026-8376

The single remaining High+ is CVE-2026-81726 in `nltk 3.10.3`. A venv dependency without a FixedVersion.

## Local Validation

I wasn't sure if we had a thorough test that includes the image (or steps), so I did the below as a minor smoke test (on `arm64`):

```sh
make build-docker-local
docker run -d --name ae -p 8001:8001 -p 4318:4318 soloio/agentevals:local
```

```sh
OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
OTEL_RESOURCE_ATTRIBUTES=agentevals.eval_set_id=wolfi-check,agentevals.session_name=wolfi-1 \
  uv run --group e2e python examples/zero-code-examples/langchain/run.py
```

**Output**
> OTLP endpoint: http://127.0.0.1:4318
>
> [1/3] User: Hi! Can you help me?
>      Agent: Of course! How can I assist you today?
>
> [2/3] User: Roll a 20-sided die for me
>      Agent: I rolled a 20-sided die and got a result of 18!
> 
> [3/3] User: Is the number you rolled prime?
>      Agent: The number 18 is not prime.
> 
> All traces and logs flushed to OTLP receiver.

```sh
curl -s http://127.0.0.1:8001/api/streaming/sessions \
  | jq '.data[] | {sessionId, spanCount, isComplete,
      invocations: [.invocations[] | {userText, agentText,
        tools: [.toolCalls[]?.name]}]}'
```

**Output**
```json
{
  "sessionId": "wolfi-1",
  "spanCount": 5,
  "isComplete": true,
  "invocations": [
    {
      "userText": "Hi! Can you help me?",
      "agentText": "Of course! How can I assist you today?",
      "tools": []
    },
    {
      "userText": "Roll a 20-sided die for me",
      "agentText": "I rolled a 20-sided die and got a result of 18!",
      "tools": [
        "roll_die"
      ]
    },
    {
      "userText": "Is the number you rolled prime?",
      "agentText": "The number 18 is not prime.",
      "tools": [
        "check_prime"
      ]
    }
  ]
}
```

---

This is a draft because I'm not 100% sure what would suffice for validation.
